### PR TITLE
test(transpiler): add emit edge cases and diagnostic path tests

### DIFF
--- a/tools/oz_transpile/tests/test_collect.py
+++ b/tools/oz_transpile/tests/test_collect.py
@@ -993,3 +993,81 @@ class TestMergeModules:
         m.classes["Foo"] = OZClass("Foo")
         merged = merge_modules([m])
         assert "Foo" in merged.classes
+
+
+class TestDiagnostics:
+    def test_unsupported_selector_skipped(self):
+        """KVO methods like forwardInvocation: should produce errors."""
+        ast = _make_ast(
+            _interface("OZObject"),
+            _impl("OZObject", methods=[
+                _method("forwardInvocation:", ret="void",
+                        params=[("inv", "id")]),
+            ]),
+        )
+        mod = collect(ast)
+        assert len(mod.classes["OZObject"].methods) == 0
+        assert any("forwardInvocation:" in e for e in mod.errors)
+
+    def test_kvo_add_observer_skipped(self):
+        ast = _make_ast(
+            _interface("OZObject"),
+            _impl("OZObject", methods=[
+                _method("addObserver:forKeyPath:options:context:", ret="void",
+                        params=[("obs", "id"), ("kp", "id"),
+                                ("opt", "int"), ("ctx", "id")]),
+            ]),
+        )
+        mod = collect(ast)
+        assert len(mod.classes["OZObject"].methods) == 0
+        assert any("addObserver:" in e for e in mod.errors)
+
+    def test_try_stmt_produces_error(self):
+        """@try statements should produce an error."""
+        ast = _make_ast(
+            _interface("Foo", "OZObject"),
+            {
+                "kind": "ObjCImplementationDecl",
+                "name": "Foo",
+                "inner": [{
+                    "kind": "ObjCMethodDecl",
+                    "name": "doWork",
+                    "returnType": {"qualType": "void"},
+                    "inner": [{
+                        "kind": "CompoundStmt",
+                        "inner": [{
+                            "kind": "ObjCAtTryStmt",
+                            "loc": {"line": 10},
+                            "inner": [],
+                        }],
+                    }],
+                }],
+            },
+        )
+        mod = collect(ast)
+        assert any("@try" in e for e in mod.errors)
+
+    def test_implicit_method_skipped(self):
+        """Implicit (compiler-generated) methods should be skipped."""
+        ast = _make_ast(
+            _impl("Foo", methods=[{
+                "kind": "ObjCMethodDecl",
+                "name": "dealloc",
+                "returnType": {"qualType": "void"},
+                "isImplicit": True,
+                "inner": [],
+            }]),
+        )
+        mod = collect(ast)
+        assert len(mod.classes["Foo"].methods) == 0
+
+    def test_weak_property_error(self):
+        """Weak properties produce an error and are not collected."""
+        ast = _make_ast(
+            _interface("Foo", "OZObject", inner=[
+                _property_decl("delegate", "id", weak=True, nonatomic=True),
+            ]),
+        )
+        mod = collect(ast)
+        assert len(mod.classes["Foo"].properties) == 0
+        assert any("weak" in e for e in mod.errors)

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -3514,3 +3514,251 @@ class TestParentIvarAccess:
             src = open(os.path.join(tmpdir, "Foundation", "OZObject_ozm.c")).read()
             assert "OZNumber_initInt32(99)" in src
             assert not m.errors
+
+
+class TestEmitEdgeCases:
+    """Tests for AST node types with missing or light coverage."""
+
+    def _emit_method(self, body_ast, class_name="Foo",
+                     method_name="doWork", ret="void"):
+        """Helper: emit a single method body and return the .c content."""
+        m = OZModule()
+        m.classes[class_name] = OZClass(class_name, methods=[
+            OZMethod(method_name, OZType(ret), body_ast=body_ast),
+        ])
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            return open(os.path.join(tmpdir, f"{class_name}_ozm.c")).read()
+
+    def test_null_stmt(self):
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{"kind": "NullStmt"}],
+        })
+        assert ";\n" in content
+
+    def test_objc_bool_literal_yes(self):
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "ReturnStmt",
+                "inner": [{
+                    "kind": "ObjCBoolLiteralExpr",
+                    "value": True,
+                }],
+            }],
+        }, ret="BOOL")
+        assert "return 1;" in content
+
+    def test_objc_bool_literal_no(self):
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "ReturnStmt",
+                "inner": [{
+                    "kind": "ObjCBoolLiteralExpr",
+                    "value": False,
+                }],
+            }],
+        }, ret="BOOL")
+        assert "return 0;" in content
+
+    def test_objc_bool_literal_string_yes(self):
+        """Clang sometimes encodes YES/NO as string values."""
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "ReturnStmt",
+                "inner": [{
+                    "kind": "ObjCBoolLiteralExpr",
+                    "value": "__objc_yes",
+                }],
+            }],
+        }, ret="BOOL")
+        assert "return 1;" in content
+
+    def test_objc_bool_literal_string_no(self):
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "ReturnStmt",
+                "inner": [{
+                    "kind": "ObjCBoolLiteralExpr",
+                    "value": "__objc_no",
+                }],
+            }],
+        }, ret="BOOL")
+        assert "return 0;" in content
+
+    def test_string_literal(self):
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "DeclStmt",
+                "inner": [{
+                    "kind": "VarDecl",
+                    "name": "s",
+                    "type": {"qualType": "const char *"},
+                    "inner": [{
+                        "kind": "StringLiteral",
+                        "value": '"hello world"',
+                    }],
+                }],
+            }],
+        })
+        assert '"hello world"' in content
+
+    def test_string_literal_escape(self):
+        content = self._emit_method({
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "DeclStmt",
+                "inner": [{
+                    "kind": "VarDecl",
+                    "name": "s",
+                    "type": {"qualType": "const char *"},
+                    "inner": [{
+                        "kind": "StringLiteral",
+                        "value": '"line\\n"',
+                    }],
+                }],
+            }],
+        })
+        assert '"line\\n"' in content
+
+    def test_array_literal(self):
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject", methods=[
+            OZMethod("init", OZType("instancetype"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{"kind": "ReturnStmt", "inner": [
+                    {"kind": "DeclRefExpr",
+                     "referencedDecl": {"name": "self"},
+                     "type": {"qualType": "OZObject *"}},
+                ]}],
+            }),
+            OZMethod("dealloc", OZType("void"), body_ast={
+                "kind": "CompoundStmt", "inner": [],
+            }),
+            OZMethod("test_lit", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "DeclStmt",
+                    "inner": [{
+                        "kind": "VarDecl",
+                        "name": "arr",
+                        "type": {"qualType": "OZArray *"},
+                        "inner": [{
+                            "kind": "ObjCArrayLiteral",
+                            "type": {"qualType": "NSArray *"},
+                            "inner": [
+                                {"kind": "ObjCStringLiteral",
+                                 "inner": [{"kind": "StringLiteral",
+                                            "value": '"a"'}]},
+                                {"kind": "ObjCStringLiteral",
+                                 "inner": [{"kind": "StringLiteral",
+                                            "value": '"b"'}]},
+                            ],
+                        }],
+                    }],
+                }],
+            }),
+        ])
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            src = open(os.path.join(tmpdir, "Foundation",
+                                    "OZObject_ozm.c")).read()
+            assert "OZArray_initWithItems" in src
+            assert "_oz_arr_" in src
+            assert not m.errors
+
+    def test_dictionary_literal(self):
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject", methods=[
+            OZMethod("init", OZType("instancetype"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{"kind": "ReturnStmt", "inner": [
+                    {"kind": "DeclRefExpr",
+                     "referencedDecl": {"name": "self"},
+                     "type": {"qualType": "OZObject *"}},
+                ]}],
+            }),
+            OZMethod("dealloc", OZType("void"), body_ast={
+                "kind": "CompoundStmt", "inner": [],
+            }),
+            OZMethod("test_lit", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "DeclStmt",
+                    "inner": [{
+                        "kind": "VarDecl",
+                        "name": "dict",
+                        "type": {"qualType": "OZDictionary *"},
+                        "inner": [{
+                            "kind": "ObjCDictionaryLiteral",
+                            "type": {"qualType": "NSDictionary *"},
+                            "inner": [
+                                {"kind": "ObjCStringLiteral",
+                                 "inner": [{"kind": "StringLiteral",
+                                            "value": '"key"'}]},
+                                {"kind": "ObjCStringLiteral",
+                                 "inner": [{"kind": "StringLiteral",
+                                            "value": '"val"'}]},
+                            ],
+                        }],
+                    }],
+                }],
+            }),
+        ])
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            src = open(os.path.join(tmpdir, "Foundation",
+                                    "OZObject_ozm.c")).read()
+            assert "OZDictionary_initWithKeysValues" in src
+            assert "_oz_dict_" in src
+            assert not m.errors
+
+    def test_forin_stmt(self):
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject", methods=[
+            OZMethod("init", OZType("instancetype"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{"kind": "ReturnStmt", "inner": [
+                    {"kind": "DeclRefExpr",
+                     "referencedDecl": {"name": "self"},
+                     "type": {"qualType": "OZObject *"}},
+                ]}],
+            }),
+            OZMethod("dealloc", OZType("void"), body_ast={
+                "kind": "CompoundStmt", "inner": [],
+            }),
+        ])
+        m.classes["Foo"] = OZClass("Foo", superclass="OZObject", methods=[
+            OZMethod("iterate", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "ObjCForCollectionStmt",
+                    "inner": [
+                        {"kind": "DeclStmt", "inner": [{
+                            "kind": "VarDecl",
+                            "name": "item",
+                            "type": {"qualType": "id"},
+                        }]},
+                        {"kind": "DeclRefExpr",
+                         "referencedDecl": {"name": "self"},
+                         "type": {"qualType": "Foo *"}},
+                        {"kind": "CompoundStmt", "inner": []},
+                    ],
+                }],
+            }),
+        ])
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            src = open(os.path.join(tmpdir, "Foo_ozm.c")).read()
+            assert "OZ_SEND_iter" in src
+            assert "OZ_SEND_next" in src
+            assert "item" in src


### PR DESCRIPTION
TestEmitEdgeCases (10 tests) covering previously untested AST nodes:
- NullStmt, ObjCBoolLiteralExpr (YES/NO, string variants), StringLiteral (plain + escape), ObjCArrayLiteral, ObjCDictionaryLiteral, ObjCForCollectionStmt (for-in)

TestDiagnostics (5 tests) covering error/diagnostic paths:
- Unsupported selectors (forwardInvocation:, KVO methods) skipped
- @try statements produce errors
- Implicit methods skipped
- Weak properties produce errors