### PR TITLE
fix(transpiler): use location-based string constant naming (OZ-039)

### DIFF
--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -1535,8 +1535,13 @@ def _emit_expr(node: dict, out: StringIO, ctx: _EmitCtx) -> None:
             name = ctx._string_dedup[val]
         else:
             raw = val[1:-1]  # strip surrounding quotes
-            name = f"_oz_str_{ctx._tmp_counter}"
-            ctx._tmp_counter += 1
+            loc = node.get("loc", {})
+            line = loc.get("line")
+            col = loc.get("col")
+            if line is not None and col is not None:
+                name = f"_oz_str_L{line}_C{col}"
+            else:
+                name = f"_oz_str_{len(ctx._string_dedup)}"
             ctx._string_dedup[val] = name
             ctx.string_constants.append(
                 f"static struct OZString {name} = {{"

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -3762,3 +3762,79 @@ class TestEmitEdgeCases:
             assert "OZ_SEND_iter" in src
             assert "OZ_SEND_next" in src
             assert "item" in src
+
+    def test_string_dedup_unique_across_methods(self):
+        """OZ-039: different string literals in separate methods must get
+        unique constant names (no _oz_str_N redefinition)."""
+        m = OZModule()
+        m.classes["Foo"] = OZClass("Foo", methods=[
+            OZMethod("hello", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "DeclStmt",
+                    "inner": [{
+                        "kind": "VarDecl",
+                        "name": "s",
+                        "type": {"qualType": "OZString *"},
+                        "inner": [{
+                            "kind": "ObjCStringLiteral",
+                            "inner": [{"kind": "StringLiteral",
+                                        "value": '"hello"'}],
+                        }],
+                    }],
+                }],
+            }),
+            OZMethod("bye", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "DeclStmt",
+                    "inner": [{
+                        "kind": "VarDecl",
+                        "name": "s",
+                        "type": {"qualType": "OZString *"},
+                        "inner": [{
+                            "kind": "ObjCStringLiteral",
+                            "inner": [{"kind": "StringLiteral",
+                                        "value": '"bye"'}],
+                        }],
+                    }],
+                }],
+            }),
+        ])
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            src = open(os.path.join(tmpdir, "Foo_ozm.c")).read()
+            assert '"hello"' in src
+            assert '"bye"' in src
+            # Each string should have a unique constant name
+            assert src.count("static struct OZString _oz_str_") == 2
+            assert not m.errors
+
+    def test_string_dedup_uses_loc_when_available(self):
+        """OZ-039: string constants use _L{line}_C{col} naming from AST loc."""
+        m = OZModule()
+        m.classes["Foo"] = OZClass("Foo", methods=[
+            OZMethod("greet", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "DeclStmt",
+                    "inner": [{
+                        "kind": "VarDecl",
+                        "name": "s",
+                        "type": {"qualType": "OZString *"},
+                        "inner": [{
+                            "kind": "ObjCStringLiteral",
+                            "loc": {"line": 10, "col": 5},
+                            "inner": [{"kind": "StringLiteral",
+                                        "value": '"hi"'}],
+                        }],
+                    }],
+                }],
+            }),
+        ])
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            src = open(os.path.join(tmpdir, "Foo_ozm.c")).read()
+            assert "_oz_str_L10_C5" in src


### PR DESCRIPTION
String dedup counter was resetting per method, causing _oz_str_N redefinition errors when different @"..." literals appeared in separate methods of the same class.

Fix: use AST source location for naming (_oz_str_L{line}_C{col}) when available, with monotonic fallback (len of dedup dict) when loc is absent (test fixtures). This makes names inherently unique across the entire translation unit.

Adds two regression tests: cross-method uniqueness and loc-based naming verification.

Resolves #67
