### PR TITLE
fix(transpiler): reject external access to protected/private ivars (OZ-043)

### DIFF
--- a/tools/oz_transpile/collect.py
+++ b/tools/oz_transpile/collect.py
@@ -385,7 +385,8 @@ def _collect_interface(node: dict, module: OZModule) -> None:
             type_info = child.get("type", {})
             qual_type = type_info.get("desugaredQualType",
                                       type_info.get("qualType", ""))
-            ivars.append(OZIvar(ivar_name, OZType(qual_type)))
+            access = child.get("access", "protected")
+            ivars.append(OZIvar(ivar_name, OZType(qual_type), access=access))
         elif ckind == "ObjCProtocol":
             proto_name = child.get("name", "")
             if proto_name and proto_name not in protocols:
@@ -435,7 +436,9 @@ def _collect_implementation(node: dict, module: OZModule) -> None:
             type_info = child.get("type", {})
             qual_type = type_info.get("desugaredQualType",
                                       type_info.get("qualType", ""))
-            cls.ivars.append(OZIvar(ivar_name, OZType(qual_type)))
+            access = child.get("access", "protected")
+            cls.ivars.append(OZIvar(ivar_name, OZType(qual_type),
+                                    access=access))
         elif ckind == "ObjCMethodDecl":
             if child.get("isImplicit"):
                 continue

--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -1453,6 +1453,23 @@ def _emit_expr(node: dict, out: StringIO, ctx: _EmitCtx) -> None:
                 base = base.get("inner", [{}])[0]
             ref_name = base.get("referencedDecl", {}).get("name", "")
             if ref_name and ref_name != "self":
+                # Enforce access control on external ivar access
+                owner = _find_ivar_owner(ivar_name, ctx.module)
+                if owner:
+                    owner_cls, ivar = owner
+                    # For free functions (method is None), use a dummy
+                    # class that never matches any real class
+                    if ctx.method is None:
+                        accessor = OZClass(name="__free_function__")
+                    else:
+                        accessor = ctx.cls
+                    if not _check_ivar_access(ivar, owner_cls,
+                                              accessor, ctx.module):
+                        ctx.module.errors.append(
+                            f"instance variable '{ivar_name}' "
+                            f"is {ivar.access}")
+                        out.write(f"/* access error: {ivar_name} */")
+                        return
                 _emit_expr(inner[0], out, ctx)
                 out.write(f"->{ivar_name}")
                 return
@@ -2510,6 +2527,39 @@ def _ivar_base_chain(ivar_name: str, cls: OZClass, module: OZModule) -> str:
         if any(iv.name == ivar_name for iv in cur.ivars):
             return "base." * depth
     return ""
+
+
+def _find_ivar_owner(ivar_name: str,
+                     module: OZModule) -> tuple[OZClass, OZIvar] | None:
+    """Find the class that declares a given ivar."""
+    for cls in module.classes.values():
+        for iv in cls.ivars:
+            if iv.name == ivar_name:
+                return cls, iv
+    return None
+
+
+def _is_subclass(cls_name: str, parent_name: str, module: OZModule) -> bool:
+    """Check if cls_name is a subclass of parent_name."""
+    cur = module.classes.get(cls_name)
+    while cur and cur.superclass:
+        if cur.superclass == parent_name:
+            return True
+        cur = module.classes.get(cur.superclass)
+    return False
+
+
+def _check_ivar_access(ivar: OZIvar, owner_cls: OZClass,
+                       accessor_cls: OZClass,
+                       module: OZModule) -> bool:
+    """Check if accessor_cls is allowed to access an ivar owned by owner_cls."""
+    if ivar.access == "public":
+        return True
+    if ivar.access == "private":
+        return accessor_cls.name == owner_cls.name
+    # protected: allow if accessor is the owner or a subclass
+    return (accessor_cls.name == owner_cls.name
+            or _is_subclass(accessor_cls.name, owner_cls.name, module))
 
 
 def _method_prototype(cls: OZClass, m: OZMethod) -> str:

--- a/tools/oz_transpile/model.py
+++ b/tools/oz_transpile/model.py
@@ -123,6 +123,7 @@ class OZProperty:
 class OZIvar:
     name: str
     oz_type: OZType
+    access: str = "protected"
 
 
 @dataclass(slots=True)

--- a/tools/oz_transpile/tests/test_collect.py
+++ b/tools/oz_transpile/tests/test_collect.py
@@ -94,6 +94,35 @@ class TestCollectInterface:
         assert mod.classes["OZObject"].superclass is None
 
 
+    def test_ivar_access_collected(self):
+        ast = _make_ast(
+            _interface("Car", "OZObject", inner=[{
+                "kind": "ObjCIvarDecl",
+                "name": "_color",
+                "type": {"qualType": "int"},
+                "access": "protected",
+            }, {
+                "kind": "ObjCIvarDecl",
+                "name": "_speed",
+                "type": {"qualType": "int"},
+                "access": "public",
+            }]),
+        )
+        mod = collect(ast)
+        ivars = mod.classes["Car"].ivars
+        assert ivars[0].name == "_color"
+        assert ivars[0].access == "protected"
+        assert ivars[1].name == "_speed"
+        assert ivars[1].access == "public"
+
+    def test_ivar_access_default_protected(self):
+        ast = _make_ast(
+            _interface("Car", "OZObject", [("_color", "int")]),
+        )
+        mod = collect(ast)
+        assert mod.classes["Car"].ivars[0].access == "protected"
+
+
 class TestCollectImplementation:
     def test_methods(self):
         body = _compound({"kind": "ReturnStmt", "inner": []})

--- a/tools/oz_transpile/tests/test_e2e.py
+++ b/tools/oz_transpile/tests/test_e2e.py
@@ -429,6 +429,116 @@ class TestCLIErrors:
             rc = main(["--input", ast_file, "--outdir", tmpdir])
             assert rc == 0
 
+    def test_external_protected_ivar_access_error(self):
+        """OZ-043: external access to protected ivar should fail."""
+        import json
+        ast = {
+            "kind": "TranslationUnitDecl",
+            "inner": [
+                {"kind": "ObjCInterfaceDecl", "name": "OZObject", "inner": []},
+                {"kind": "ObjCImplementationDecl", "name": "OZObject",
+                 "inner": [
+                     {"kind": "ObjCMethodDecl", "name": "init",
+                      "returnType": {"qualType": "instancetype"},
+                      "inner": [{"kind": "CompoundStmt", "inner": [
+                          {"kind": "ReturnStmt", "inner": [
+                              {"kind": "DeclRefExpr",
+                               "referencedDecl": {"name": "self"},
+                               "type": {"qualType": "OZObject *"}}]}]}]},
+                     {"kind": "ObjCMethodDecl", "name": "dealloc",
+                      "returnType": {"qualType": "void"},
+                      "inner": [{"kind": "CompoundStmt", "inner": []}]},
+                 ]},
+                {"kind": "ObjCInterfaceDecl", "name": "Car",
+                 "super": {"name": "OZObject"},
+                 "inner": [
+                     {"kind": "ObjCIvarDecl", "name": "_color",
+                      "type": {"qualType": "int"},
+                      "access": "protected"},
+                 ]},
+                {"kind": "ObjCImplementationDecl", "name": "Car",
+                 "super": {"name": "OZObject"}, "inner": []},
+                {"kind": "FunctionDecl", "name": "main",
+                 "type": {"qualType": "int ()"},
+                 "inner": [{"kind": "CompoundStmt", "inner": [{
+                     "kind": "ObjCIvarRefExpr",
+                     "decl": {"name": "_color"},
+                     "isFreeIvar": False,
+                     "inner": [{
+                         "kind": "ImplicitCastExpr",
+                         "castKind": "LValueToRValue",
+                         "inner": [{
+                             "kind": "DeclRefExpr",
+                             "referencedDecl": {"name": "myCar"},
+                             "type": {"qualType": "Car *"},
+                         }],
+                     }],
+                 }]}],
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ast_file = os.path.join(tmpdir, "protected.ast.json")
+            with open(ast_file, "w") as f:
+                json.dump(ast, f)
+            rc = main(["--input", ast_file, "--outdir", tmpdir])
+            assert rc == 1
+
+    def test_external_public_ivar_access_succeeds(self):
+        """OZ-043: external access to public ivar should succeed."""
+        import json
+        ast = {
+            "kind": "TranslationUnitDecl",
+            "inner": [
+                {"kind": "ObjCInterfaceDecl", "name": "OZObject", "inner": []},
+                {"kind": "ObjCImplementationDecl", "name": "OZObject",
+                 "inner": [
+                     {"kind": "ObjCMethodDecl", "name": "init",
+                      "returnType": {"qualType": "instancetype"},
+                      "inner": [{"kind": "CompoundStmt", "inner": [
+                          {"kind": "ReturnStmt", "inner": [
+                              {"kind": "DeclRefExpr",
+                               "referencedDecl": {"name": "self"},
+                               "type": {"qualType": "OZObject *"}}]}]}]},
+                     {"kind": "ObjCMethodDecl", "name": "dealloc",
+                      "returnType": {"qualType": "void"},
+                      "inner": [{"kind": "CompoundStmt", "inner": []}]},
+                 ]},
+                {"kind": "ObjCInterfaceDecl", "name": "Car",
+                 "super": {"name": "OZObject"},
+                 "inner": [
+                     {"kind": "ObjCIvarDecl", "name": "_color",
+                      "type": {"qualType": "int"},
+                      "access": "public"},
+                 ]},
+                {"kind": "ObjCImplementationDecl", "name": "Car",
+                 "super": {"name": "OZObject"}, "inner": []},
+                {"kind": "FunctionDecl", "name": "main",
+                 "type": {"qualType": "int ()"},
+                 "inner": [{"kind": "CompoundStmt", "inner": [{
+                     "kind": "ObjCIvarRefExpr",
+                     "decl": {"name": "_color"},
+                     "isFreeIvar": False,
+                     "inner": [{
+                         "kind": "ImplicitCastExpr",
+                         "castKind": "LValueToRValue",
+                         "inner": [{
+                             "kind": "DeclRefExpr",
+                             "referencedDecl": {"name": "myCar"},
+                             "type": {"qualType": "Car *"},
+                         }],
+                     }],
+                 }]}],
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ast_file = os.path.join(tmpdir, "public.ast.json")
+            with open(ast_file, "w") as f:
+                json.dump(ast, f)
+            rc = main(["--input", ast_file, "--outdir", tmpdir])
+            assert rc == 0
+
     def test_unsupported_method_selector_error(self):
         """Methods with unsupported selectors should produce errors."""
         import json

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -4015,3 +4015,167 @@ class TestEmitEdgeCases:
             src = open(os.path.join(tmpdir, "Foo_ozm.c")).read()
             # Should have exactly one release call, not two
             assert src.count("OZObject_release") == 1
+
+
+class TestIvarAccessControl:
+    def test_external_ivar_access_protected_rejected(self):
+        """External access to a protected ivar from a free function is rejected."""
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject")
+        m.classes["Car"] = OZClass(
+            "Car", superclass="OZObject",
+            ivars=[OZIvar("_color", OZType("int"), access="protected")],
+        )
+        m.functions.append(OZFunction("main", OZType("int"), body_ast={
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "ObjCIvarRefExpr",
+                "decl": {"name": "_color"},
+                "isFreeIvar": False,
+                "inner": [{
+                    "kind": "ImplicitCastExpr",
+                    "castKind": "LValueToRValue",
+                    "inner": [{
+                        "kind": "DeclRefExpr",
+                        "referencedDecl": {"name": "myCar"},
+                        "type": {"qualType": "Car *"},
+                    }],
+                }],
+            }],
+        }))
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+        assert any("_color" in e and "protected" in e for e in m.errors)
+
+    def test_external_ivar_access_public_allowed(self):
+        """External access to a public ivar is allowed."""
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject")
+        m.classes["Car"] = OZClass(
+            "Car", superclass="OZObject",
+            ivars=[OZIvar("_color", OZType("int"), access="public")],
+        )
+        m.functions.append(OZFunction("main", OZType("int"), body_ast={
+            "kind": "CompoundStmt",
+            "inner": [{
+                "kind": "ObjCIvarRefExpr",
+                "decl": {"name": "_color"},
+                "isFreeIvar": False,
+                "inner": [{
+                    "kind": "ImplicitCastExpr",
+                    "castKind": "LValueToRValue",
+                    "inner": [{
+                        "kind": "DeclRefExpr",
+                        "referencedDecl": {"name": "myCar"},
+                        "type": {"qualType": "Car *"},
+                    }],
+                }],
+            }],
+        }))
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+        assert not any("_color" in e for e in m.errors)
+
+    def test_external_ivar_access_private_rejected(self):
+        """External access to a private ivar from a subclass is rejected."""
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject")
+        m.classes["Car"] = OZClass(
+            "Car", superclass="OZObject",
+            ivars=[OZIvar("_secret", OZType("int"), access="private")],
+        )
+        m.classes["SportsCar"] = OZClass(
+            "SportsCar", superclass="Car",
+            methods=[OZMethod("reveal", OZType("void"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "ObjCIvarRefExpr",
+                    "decl": {"name": "_secret"},
+                    "isFreeIvar": False,
+                    "inner": [{
+                        "kind": "ImplicitCastExpr",
+                        "castKind": "LValueToRValue",
+                        "inner": [{
+                            "kind": "DeclRefExpr",
+                            "referencedDecl": {"name": "other"},
+                            "type": {"qualType": "Car *"},
+                        }],
+                    }],
+                }],
+            })],
+        )
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+        assert any("_secret" in e and "private" in e for e in m.errors)
+
+    def test_protected_ivar_access_from_subclass_allowed(self):
+        """Subclass method accessing protected ivar externally on another
+        instance is still external — but self-access through isFreeIvar
+        is not affected.  This test checks the subclass self-access path."""
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject")
+        m.classes["Car"] = OZClass(
+            "Car", superclass="OZObject",
+            ivars=[OZIvar("_color", OZType("int"), access="protected")],
+        )
+        m.classes["SportsCar"] = OZClass(
+            "SportsCar", superclass="Car",
+            methods=[OZMethod("getColor", OZType("int"), body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "ReturnStmt",
+                    "inner": [{
+                        "kind": "ObjCIvarRefExpr",
+                        "decl": {"name": "_color"},
+                        "isFreeIvar": True,
+                    }],
+                }],
+            })],
+        )
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            content = open(os.path.join(tmpdir, "SportsCar_ozm.c")).read()
+            assert "self->base._color" in content
+        assert not m.errors
+
+    def test_protected_external_access_from_subclass_method(self):
+        """Subclass accessing protected ivar on another instance (not self)
+        should be allowed since accessor is a subclass of owner."""
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject")
+        m.classes["Car"] = OZClass(
+            "Car", superclass="OZObject",
+            ivars=[OZIvar("_color", OZType("int"), access="protected")],
+        )
+        m.classes["SportsCar"] = OZClass(
+            "SportsCar", superclass="Car",
+            methods=[OZMethod("copyColor:", OZType("void"),
+                              params=[OZParam("other", OZType("Car *"))],
+                              body_ast={
+                "kind": "CompoundStmt",
+                "inner": [{
+                    "kind": "ObjCIvarRefExpr",
+                    "decl": {"name": "_color"},
+                    "isFreeIvar": False,
+                    "inner": [{
+                        "kind": "ImplicitCastExpr",
+                        "castKind": "LValueToRValue",
+                        "inner": [{
+                            "kind": "DeclRefExpr",
+                            "referencedDecl": {"name": "other"},
+                            "type": {"qualType": "Car *"},
+                        }],
+                    }],
+                }],
+            })],
+        )
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            content = open(os.path.join(tmpdir, "SportsCar_ozm.c")).read()
+            assert "other->_color" in content
+        assert not m.errors


### PR DESCRIPTION
## Summary

  - Add `access` field to `OZIvar` model (defaults to `"protected"` per ObjC spec)
  - Parse `"access"` from Clang AST `ObjCIvarDecl` nodes in collect pass
  - Enforce visibility rules in emit pass: protected ivars only accessible from declaring class/subclasses, private only from
  declaring class, public always allowed
  - Free functions (main, helpers) are never considered part of any class, so protected/private access is always rejected there

  ## Test plan

  - [x] `test_ivar_access_collected` / `test_ivar_access_default_protected` — collect pass parses access correctly
  - [x] `test_external_ivar_access_protected_rejected` — free function accessing protected ivar → error
  - [x] `test_external_ivar_access_public_allowed` — free function accessing public ivar → ok
  - [x] `test_external_ivar_access_private_rejected` — subclass method accessing private ivar → error
  - [x] `test_protected_ivar_access_from_subclass_allowed` — subclass self-access to inherited protected ivar → ok
  - [x] `test_protected_external_access_from_subclass_method` — subclass accessing protected ivar on another instance → ok
  - [x] E2E: `test_external_protected_ivar_access_error` (rc=1), `test_external_public_ivar_access_succeeds` (rc=0)
  - [x] Full suite: 425 tests pass

Resolves #69
