### PR TITLE
fix(transpiler): use per-object spinlock for atomic property accessors (OZ-045)

### DIFF
--- a/tools/oz_transpile/context.py
+++ b/tools/oz_transpile/context.py
@@ -237,7 +237,7 @@ def _build_impl_context(
         buf = StringIO()
         buf.write(f"{_method_prototype(cls, m)}\n")
         if m.synthesized_property:
-            _emit_synthesized_accessor(cls, m, buf, root_class)
+            _emit_synthesized_accessor(cls, m, buf, root_class, module)
         elif m.body_ast:
             _emit_compound_stmt(m.body_ast, buf, ctx, indent=0,
                                 param_retains=_object_params(m))
@@ -273,7 +273,7 @@ def _build_impl_context(
         buf = StringIO()
         buf.write(f"{_method_prototype(cls, m)}\n")
         if m.synthesized_property:
-            _emit_synthesized_accessor(cls, m, buf, root_class)
+            _emit_synthesized_accessor(cls, m, buf, root_class, module)
         elif m.body_ast:
             _emit_compound_stmt(m.body_ast, buf, ctx, indent=0,
                                 param_retains=_object_params(m))

--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -449,6 +449,19 @@ def _class_header_ctx(ctx: _EmitCtx, stem: str | None = None,
          "field": "u16"},
     ]
 
+    # Check if any class in the module uses atomic properties — the lock
+    # field lives in the root class so it must be emitted when any class
+    # in the hierarchy needs it.
+    has_atomic_props = False
+    if is_root:
+        for c in module.classes.values():
+            for p in c.properties:
+                if not p.is_nonatomic:
+                    has_atomic_props = True
+                    break
+            if has_atomic_props:
+                break
+
     return {
         "name": cls.name,
         "stem": stem or _header_stem(cls),
@@ -467,6 +480,7 @@ def _class_header_ctx(ctx: _EmitCtx, stem: str | None = None,
         "number_inits": number_inits,
         "item_pool_count": item_pool_count,
         "user_includes": cls.user_includes,
+        "has_atomic_props": has_atomic_props,
     }
 
 
@@ -474,9 +488,20 @@ def _class_header_ctx(ctx: _EmitCtx, stem: str | None = None,
 # Synthesized property accessors
 # ---------------------------------------------------------------------------
 
+def _self_lock_chain(cls: OZClass, module: OZModule) -> str:
+    """Build 'self->base.base..._oz_prop_lock' for reaching the root lock field."""
+    parts = []
+    cur = cls
+    while cur.superclass and cur.superclass in module.classes:
+        parts.append("base.")
+        cur = module.classes[cur.superclass]
+    return "self->" + "".join(parts) + "_oz_prop_lock"
+
+
 def _emit_synthesized_accessor(cls: OZClass, m: OZMethod,
                                 out: StringIO,
-                                root_class: str = "OZObject") -> None:
+                                root_class: str = "OZObject",
+                                module: OZModule | None = None) -> None:
     """Emit a synthesized getter or setter for a property."""
     prop = m.synthesized_property
     ivar = prop.ivar_name
@@ -486,12 +511,13 @@ def _emit_synthesized_accessor(cls: OZClass, m: OZMethod,
     is_strong_obj = prop.oz_type.is_object and prop.ownership == "strong"
     root = root_class
 
+    lock_expr = _self_lock_chain(cls, module) if (is_atomic and module) else None
+
     if is_getter:
         if is_atomic:
             out.write("{\n")
-            out.write("\toz_spinlock_t lck;\n")
             out.write(f"\t{c_type} val;\n")
-            out.write("\tOZ_SPINLOCK(&lck) {\n")
+            out.write(f"\tOZ_SPINLOCK(&{lock_expr}) {{\n")
             out.write(f"\t\tval = self->{ivar};\n")
             out.write("\t}\n")
             out.write("\treturn val;\n")
@@ -505,10 +531,9 @@ def _emit_synthesized_accessor(cls: OZClass, m: OZMethod,
         if is_strong_obj:
             if is_atomic:
                 out.write("{\n")
-                out.write("\toz_spinlock_t lck;\n")
                 out.write(f"\t{c_type} old;\n")
                 out.write(f"\t{root}_retain((struct {root} *){param_name});\n")
-                out.write("\tOZ_SPINLOCK(&lck) {\n")
+                out.write(f"\tOZ_SPINLOCK(&{lock_expr}) {{\n")
                 out.write(f"\t\told = self->{ivar};\n")
                 out.write(f"\t\tself->{ivar} = {param_name};\n")
                 out.write("\t}\n")
@@ -524,8 +549,7 @@ def _emit_synthesized_accessor(cls: OZClass, m: OZMethod,
         else:
             if is_atomic:
                 out.write("{\n")
-                out.write("\toz_spinlock_t lck;\n")
-                out.write("\tOZ_SPINLOCK(&lck) {\n")
+                out.write(f"\tOZ_SPINLOCK(&{lock_expr}) {{\n")
                 out.write(f"\t\tself->{ivar} = {param_name};\n")
                 out.write("\t}\n")
                 out.write("}\n")
@@ -595,7 +619,7 @@ def _class_source_ctx(ctx: _EmitCtx, stem: str | None = None,
         buf = StringIO()
         buf.write(f"{_method_prototype(cls, m)}\n")
         if m.synthesized_property:
-            _emit_synthesized_accessor(cls, m, buf, root_class)
+            _emit_synthesized_accessor(cls, m, buf, root_class, ctx.module)
         elif m.body_ast:
             _emit_compound_stmt(m.body_ast, buf, ctx, indent=0,
                                 param_retains=_object_params(m))

--- a/tools/oz_transpile/templates/class_header.h.j2
+++ b/tools/oz_transpile/templates/class_header.h.j2
@@ -23,6 +23,9 @@ struct {{ name }} {
 {% if is_root %}
 	enum oz_class_id oz_class_id;
 	oz_atomic_t _refcount;
+{% if has_atomic_props %}
+	oz_spinlock_t _oz_prop_lock;
+{% endif %}
 {% else %}
 	struct {{ superclass }} base;
 {% endif %}

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -173,6 +173,37 @@ class TestClassHeader:
             assert "oz_class_id" in content
             assert "_refcount" in content
 
+    def test_root_struct_no_atomic_props(self):
+        """Root struct omits _oz_prop_lock when no atomic properties exist."""
+        m = _simple_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            content = open(os.path.join(tmpdir, "Foundation", "OZObject_ozh.h")).read()
+            assert "_oz_prop_lock" not in content
+
+    def test_root_struct_with_atomic_props(self):
+        """Root struct includes _oz_prop_lock when atomic properties exist."""
+        m = OZModule()
+        m.classes["OZObject"] = OZClass("OZObject")
+        m.classes["Car"] = OZClass(
+            "Car", superclass="OZObject",
+            properties=[OZProperty("speed", OZType("int"),
+                                   ivar_name="_speed", is_nonatomic=False)],
+            ivars=[OZIvar("_speed", OZType("int"))],
+            methods=[
+                OZMethod("speed", OZType("int"),
+                         synthesized_property=OZProperty(
+                             "speed", OZType("int"),
+                             ivar_name="_speed", is_nonatomic=False,
+                             ownership="assign")),
+            ],
+        )
+        resolve(m)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emit(m, tmpdir)
+            content = open(os.path.join(tmpdir, "Foundation", "OZObject_ozh.h")).read()
+            assert "oz_spinlock_t _oz_prop_lock;" in content
+
 
 class TestClassSource:
     def test_method_body(self):
@@ -2055,10 +2086,17 @@ class TestStaticVarEmission:
 class TestSynthesizedPropertyEmission:
     """Test _emit_synthesized_accessor generates correct C code."""
 
-    def _emit(self, cls, method, root_class="OZObject"):
+    def _emit(self, cls, method, root_class="OZObject", module=None):
         from io import StringIO
+        if module is None:
+            root = OZClass(root_class)
+            module = OZModule()
+            module.classes[root_class] = root
+            if cls.name != root_class:
+                cls.superclass = root_class
+                module.classes[cls.name] = cls
         buf = StringIO()
-        _emit_synthesized_accessor(cls, method, buf, root_class)
+        _emit_synthesized_accessor(cls, method, buf, root_class, module)
         return buf.getvalue()
 
     def test_nonatomic_getter(self):
@@ -2080,8 +2118,8 @@ class TestSynthesizedPropertyEmission:
         m = OZMethod("model", OZType("OZString *"),
                      synthesized_property=prop)
         code = self._emit(cls, m)
-        assert "oz_spinlock_t lck;" in code
-        assert "OZ_SPINLOCK(&lck)" in code
+        assert "oz_spinlock_t" not in code
+        assert "OZ_SPINLOCK(&self->base._oz_prop_lock)" in code
         assert "val = self->_model;" in code
         assert "return val;" in code
 
@@ -2108,8 +2146,8 @@ class TestSynthesizedPropertyEmission:
                      params=[OZParam("model", OZType("OZString *"))],
                      synthesized_property=prop)
         code = self._emit(cls, m, root_class="OZObject")
-        assert "oz_spinlock_t lck;" in code
-        assert "OZ_SPINLOCK(&lck)" in code
+        assert "oz_spinlock_t" not in code
+        assert "OZ_SPINLOCK(&self->base._oz_prop_lock)" in code
         assert "OZObject_retain(" in code
         assert "OZObject_release(" in code
 
@@ -2136,8 +2174,8 @@ class TestSynthesizedPropertyEmission:
                      params=[OZParam("speed", OZType("int"))],
                      synthesized_property=prop)
         code = self._emit(cls, m)
-        assert "oz_spinlock_t lck;" in code
-        assert "OZ_SPINLOCK(&lck)" in code
+        assert "oz_spinlock_t" not in code
+        assert "OZ_SPINLOCK(&self->base._oz_prop_lock)" in code
         assert "self->_speed = speed;" in code
         assert "retain" not in code
         assert "release" not in code
@@ -2154,6 +2192,23 @@ class TestSynthesizedPropertyEmission:
         assert "self->_delegate = delegate;" in code
         assert "retain" not in code
         assert "release" not in code
+
+    def test_atomic_getter_child_class(self):
+        """Grandchild class uses base.base. chain to reach root lock."""
+        prop = OZProperty("temp", OZType("int"),
+                          ivar_name="_temp", is_nonatomic=False,
+                          ownership="assign")
+        root = OZClass("OZObject")
+        mid = OZClass("Vehicle", superclass="OZObject")
+        child = OZClass("Car", superclass="Vehicle")
+        module = OZModule()
+        module.classes["OZObject"] = root
+        module.classes["Vehicle"] = mid
+        module.classes["Car"] = child
+        m = OZMethod("temp", OZType("int"), synthesized_property=prop)
+        code = self._emit(child, m, module=module)
+        assert "OZ_SPINLOCK(&self->base.base._oz_prop_lock)" in code
+        assert "oz_spinlock_t" not in code
 
 
 class TestSynchronized:


### PR DESCRIPTION
 ## Summary

  - Atomic property accessors emitted `oz_spinlock_t lck;` as an uninitialized stack variable, causing Zephyr `K_SPINLOCK` to
  crash at runtime
  - Replace local spinlock with a `_oz_prop_lock` field in the root class struct, zero-initialized by `alloc`'s `memset(0)` —
  valid for both Zephyr (`K_SPINLOCK_INITIALIZER = {}`) and Host (`int` zero) backends
  - Fix two additional call sites in `context.py` (patched/roundtrip emission) that were missing the `module` argument, producing
  `OZ_SPINLOCK(&None)` in generated C

  ## Changes

  - **`emit.py`** — `_self_lock_chain()` helper computes `self->base.base..._oz_prop_lock` chain; `_emit_synthesized_accessor()`
  uses per-object lock; `_class_header_ctx()` computes `has_atomic_props`
  - **`context.py`** — Pass `module` to `_emit_synthesized_accessor()` in both roundtrip call sites
  - **`class_header.h.j2`** — Conditionally emit `oz_spinlock_t _oz_prop_lock` in root struct
  - **`test_emit.py`** — Update 3 atomic tests, add child class chain test, add root struct header tests (+6 tests)

  ## Test plan

  - [x] `just test-transpiler` — 428 tests pass
  - [x] `just test` — full suite (twister 10/10, transpiler, behavior, adapted)
  - [x] `just project_dir=samples/hello_category clean rebuild` — builds and links successfully
  - [x] `just project_dir=samples/hello_category run` — no runtime crash on atomic getter

Resolves #70
