### PR TITLE
fix(samples): resolve OZ-043 and OZ-045

### DIFF
--- a/issues/OZ-043.md
+++ b/issues/OZ-043.md
@@ -1,15 +1,15 @@
 # OZ-043: Transpiler allows direct ivar access from outside class via arrow operator
 
-- **status:** open
+- **status:** resolved
 - **filed-by:** MAINTAINER
 - **date:** 2026-03-17
 - **blocking:** NO
 - **assigned-to:** MAINTAINER
-- **resolved-by:**
-- **resolved-date:**
+- **resolved-by:** MAINTAINER
+- **resolved-date:** 2026-03-17
 - **qa-review:**
 - **verified-by:**
-- **commit:**
+- **commit:** 96815f9
 
 ## Context
 
@@ -63,4 +63,6 @@ Use property accessors instead of direct ivar access from outside the class.
 
 ## Resolution
 
-(filled by MAINTAINER when fixed)
+Fixed in commit 96815f9. The transpiler now rejects external access to
+`@protected` and `@private` ivars via the arrow operator, emitting an
+error diagnostic at transpile time.

--- a/issues/OZ-045.md
+++ b/issues/OZ-045.md
@@ -1,15 +1,15 @@
 # OZ-045: Atomic property getter uses uninitialized local spinlock — crashes at runtime
 
-- **status:** open
+- **status:** resolved
 - **filed-by:** MAINTAINER
 - **date:** 2026-03-17
 - **blocking:** YES
 - **assigned-to:** MAINTAINER
-- **resolved-by:**
-- **resolved-date:**
+- **resolved-by:** MAINTAINER
+- **resolved-date:** 2026-03-17
 - **qa-review:**
 - **verified-by:**
-- **commit:**
+- **commit:** c9fe84d
 
 ## Context
 
@@ -77,4 +77,6 @@ Declare properties as `nonatomic` to avoid the spinlock path:
 
 ## Resolution
 
-(filled by MAINTAINER when fixed)
+Fixed in commit c9fe84d. Atomic property getters now use the per-object
+spinlock (`self->base._oz_lock`) instead of an uninitialized local
+variable, eliminating the runtime crash.

--- a/samples/hello_category/include/Car.h
+++ b/samples/hello_category/include/Car.h
@@ -10,15 +10,13 @@ struct color {
 };
 
 @interface Car: OZObject {
-	struct color *_color;
-	OZString *_model;
-	int _throttleLevel;
-	int _breakLevel;
+      @public
+	int _plate;
 }
 
 @property(readonly) struct color *color;
-
 @property(readonly, atomic) OZString *model;
+
 - (Car *)initWithColor:(struct color *)c andModel:(OZString *)model;
 
 - (BOOL)throttleWithLevel:(int)level;

--- a/samples/hello_category/src/Car.m
+++ b/samples/hello_category/src/Car.m
@@ -2,7 +2,12 @@
 #import <objc/objc.h>
 #include "Car.h"
 
-@implementation Car
+@implementation Car {
+	struct color *_color;
+	OZString *_model;
+	int _throttleLevel;
+	int _breakLevel;
+}
 
 @synthesize color = _color;
 @synthesize model = _model;

--- a/samples/hello_category/src/main.m
+++ b/samples/hello_category/src/main.m
@@ -13,11 +13,14 @@ int main(void)
 	Car *myCar = [[Car alloc] initWithColor:&(struct color){255, 255, 0}
 				       andModel:@"Honda Civic"];
 
+	myCar->_plate = 0xAABBCC;
+	oz_assert(myCar->_plate == 0xAABBCC);
 	oz_assert([myCar throttleWithLevel:50] == YES);
 	oz_assert([myCar breakWithLevel:20] == NO);
 	oz_assert([myCar throttleWithLevel:0] == YES);
 	oz_assert([myCar breakWithLevel:20] == YES);
 	oz_assert([myCar milage] != 0);
+	oz_assert([[myCar model] isEqual:@"Honda Civic"]);
 
 	OZLog("All assertions passed");
 	return 0;


### PR DESCRIPTION
## Summary

- Mark **OZ-043** (ivar access control enforcement) as resolved (commit `96815f9`)
- Mark **OZ-045** (atomic spinlock crash) as resolved (commit `c9fe84d`)
- Update `hello_category` sample: move private ivars to `@implementation` block, add `@public` ivar access test, add atomic property assertion

## Test plan

- [x] `just test` passes (twister + transpiler + behavior + adapted)
- [x] `hello_category` sample builds and runs in QEMU without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)