### PR TITLE
docs(issues): resolve OZ-047, OZ-049, OZ-051; file OZ-053

### DIFF
--- a/issues/OZ-047.md
+++ b/issues/OZ-047.md
@@ -1,15 +1,15 @@
 # OZ-047: Add OZDefer Foundation class with deferred cleanup block
 
-- **status:** open
+- **status:** resolved
 - **filed-by:** MAINTAINER
 - **date:** 2026-03-18
 - **blocking:** NO
 - **assigned-to:** MAINTAINER
-- **resolved-by:**
-- **resolved-date:**
+- **resolved-by:** MAINTAINER
+- **resolved-date:** 2026-03-18
 - **qa-review:**
 - **verified-by:**
-- **commit:**
+- **commit:** 042de79
 
 ## Context
 
@@ -42,4 +42,8 @@ when OZDefer stores a back-reference to its owner.
 
 ## Resolution
 
-(filled by MAINTAINER when fixed)
+Added OZDefer Foundation class with `initWithOwner:block:` and `initWithBlock:`
+convenience init. Block fires during dealloc with owner pointer (or nil).
+Owner stored as `__unsafe_unretained id` to avoid retain cycles.
+Registered in Foundation.h umbrella, transpiler _FOUNDATION_NAMES, and
+_OZ_INCLUDE_PREFIXES. PR #21.

--- a/issues/OZ-049.md
+++ b/issues/OZ-049.md
@@ -1,15 +1,15 @@
 # OZ-049: Block-typed ivar generates invalid C struct field declaration
 
-- **status:** open
+- **status:** resolved
 - **filed-by:** MAINTAINER
 - **date:** 2026-03-18
 - **blocking:** NO
 - **assigned-to:** MAINTAINER
-- **resolved-by:**
-- **resolved-date:**
+- **resolved-by:** MAINTAINER
+- **resolved-date:** 2026-03-18
 - **qa-review:**
 - **verified-by:**
-- **commit:**
+- **commit:** 042de79
 
 ## Context
 
@@ -49,4 +49,8 @@ struct Handler {
 
 ## Resolution
 
-(filled by MAINTAINER when fixed)
+Changed class_header.h.j2 template to use `ivar.decl` (via `c_param_decl()`)
+instead of `ivar.c_type + ivar.name` for struct field declarations. This
+embeds the field name inside the function pointer syntax: `void (*_name)(T)`
+instead of invalid `void (*)(T) _name`. Added `decl` field to user_ivars dict
+in emit.py. Compiled C regression test and transpiler unit test added. PR #21.

--- a/issues/OZ-051.md
+++ b/issues/OZ-051.md
@@ -1,15 +1,15 @@
 # OZ-051: __unsafe_unretained ignored on ivars — treated as strong
 
-- **status:** open
+- **status:** resolved
 - **filed-by:** MAINTAINER
 - **date:** 2026-03-18
 - **blocking:** NO
 - **assigned-to:** MAINTAINER
-- **resolved-by:**
-- **resolved-date:**
+- **resolved-by:** MAINTAINER
+- **resolved-date:** 2026-03-18
 - **qa-review:**
 - **verified-by:**
-- **commit:**
+- **commit:** 042de79
 
 ## Context
 
@@ -62,4 +62,8 @@ void Watcher_dealloc(struct Watcher *self)
 
 ## Resolution
 
-(filled by MAINTAINER when fixed)
+Added `is_unretained` property to OZType in model.py. Updated 5 locations in
+emit.py to filter out `__unsafe_unretained` ivars from auto-retain/release:
+`_has_auto_dealloc`, auto-dealloc proto, `_is_object_ivar_assign`,
+`_emit_user_dealloc`, and `_emit_auto_dealloc`. Transpiler unit test added.
+PR #21.

--- a/issues/OZ-053.md
+++ b/issues/OZ-053.md
@@ -1,0 +1,47 @@
+# OZ-053: CI zephyr-integration fails — SDK version mismatch
+
+- **status:** open
+- **filed-by:** MAINTAINER
+- **date:** 2026-03-18
+- **blocking:** NO
+- **assigned-to:** MAINTAINER
+- **resolved-by:**
+- **resolved-date:**
+- **qa-review:**
+- **verified-by:**
+- **commit:**
+
+## Context
+
+The `zephyr-integration` CI job fails on every PR. Discovered during PR #21
+(OZ-047). All other CI checks pass (behavior-tests, python-tests, sanitizers,
+c-coverage, generated-freshness).
+
+## Input
+
+CI runs `west twister -T tests/zephyr/ -p native_sim --inline-logs` with
+`ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.17.4`.
+
+## Observed
+
+```
+CMake Error at /__w/objective-z/zephyr/cmake/modules/FindZephyr-sdk.cmake:81 (find_package):
+  Could not find a configuration file for package "Zephyr-sdk" that is
+  compatible with requested version "1.0".
+
+  The following configuration files were considered but not accepted:
+    /opt/toolchains/zephyr-sdk-0.17.4/cmake/Zephyr-sdkConfig.cmake, version: 0.17.4
+```
+
+## Expected
+
+CI should use a Zephyr SDK version compatible with the Zephyr tree pinned in
+`west.yml`, or the Zephyr tree version should be aligned with the installed SDK.
+
+## Workaround
+
+None — `zephyr-integration` job is currently broken on all PRs.
+
+## Resolution
+
+(filled by MAINTAINER when fixed)


### PR DESCRIPTION
## Summary
- Mark OZ-047, OZ-049, OZ-051 as resolved (commit 042de79, PR #21)
- File OZ-053: CI zephyr-integration fails due to SDK version mismatch (0.17.4 vs required 1.0)

## Test Plan
- Docs-only change — no code modified