### PR TITLE
feat(transpiler): migrate test_emit.py to real .m sources (OZ-060)

### DIFF
--- a/tools/oz_transpile/tests/conftest.py
+++ b/tools/oz_transpile/tests/conftest.py
@@ -47,7 +47,7 @@ def clang_collect(source, *, extra_files=None):
         result = subprocess.run(
             [
                 "clang", "-Xclang", "-ast-dump=json", "-fsyntax-only",
-                "-fobjc-runtime=macosx",
+                "-fobjc-runtime=macosx", "-fblocks",
                 "-I", OZ_SDK_DIR, "-I", tmpdir, src_path,
             ],
             capture_output=True,

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -2396,9 +2396,6 @@ class TestReturnProtocolDispatch:
         _, out = clang_emit("""\
 #import <Foundation/OZObject.h>
 #import <Foundation/OZArray.h>
-@protocol IteratorProtocol
-- (unsigned int)count;
-@end
 @interface Registry : OZObject {
     OZArray *_sensors;
 }


### PR DESCRIPTION
## Summary
- Closes #80 (OZ-060: Migrate test_emit.py from synthetic OZModule to real `.m` sources)
- Migrates ~140 of 176 emit tests from handcrafted synthetic AST to real ObjC compiled through Clang
- Adds `clang_emit()` helper to conftest.py for full pipeline testing
- Reduces test file from 4408 to 3385 lines (-23%)

## Changes
- `tools/oz_transpile/tests/conftest.py`: Add `clang_emit()` helper (compile → collect → resolve → emit → dict)
- `tools/oz_transpile/tests/test_emit.py`: Rewrite ~140 tests to use real `.m` sources

## Tests kept synthetic (intentional corner cases or Clang limitations)
- **TestHelpers**: Pure utility function tests (`_selector_to_c`, `_base_chain`, etc.)
- **TestSynthesizedPropertyEmission**: Tests `_emit_synthesized_accessor` directly
- **TestPatchedEmission**: Tests tree-sitter patched source functions
- **`__unsafe_unretained` ivar**: Clang JSON AST doesn't preserve the qualifier
- **`id`-typed protocol dispatch**: Real Clang resolves dispatch differently
- **`@(uint16_t)`/`@(double)` boxing**: OZ SDK doesn't define those converters
- **String loc-based naming**: Temp file locs don't match expected format
- **Ivar access control rejection**: Clang rejects invalid access before transpiler
- **GCC compile test**: Needs precise control over generated dealloc chain

## Embedded Considerations
- Footprint: no change
- Performance: no change (test-only)
- Reliability: improved — real Clang AST catches parser bugs that synthetic tests missed

## Test Plan
- [x] `just test-transpiler` — 453 passed
- [x] `just test-behavior` — 39 passed
- [x] `just test-adapted` — 12 passed