### PR TITLE
feat(sdk): rename OZLock to OZSpinLock as Foundation class (OZ-066)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Zero-cost abstraction for transpiler-generated C:
 - **`oz_platform_zephyr.h`** — Zephyr backend: k_mem_slab, Zephyr atomics, spinlock, printk
 - **`oz_platform_host.h`** — Host backend: malloc-backed slab, C11 stdatomic, printf
 - **`oz_platform_types.h`** — Shared type definitions
-- **`oz_lock.h`** — OZLock RAII spinlock wrapper for `@synchronized`
+- **`oz_lock.h`** — OZSpinLock RAII spinlock struct for `@synchronized`
 
 All PAL functions are `static inline` — vanish at -O1+.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All benchmarks on **nRF52833 DK** (ARM Cortex-M4F @ 64 MHz), DWT cycle counter, 
 - **Compile-time ARC** — scope-based retain/release, auto-dealloc, break/continue cleanup
 - **Categories** — merged at AST collection time
 - **`@property` / `@synthesize`** — atomic and strong semantics
-- **`@synchronized`** — RAII spinlock via OZLock
+- **`@synchronized`** — RAII spinlock via OZSpinLock
 - **`@autoreleasepool`** — scoped memory management
 - **Blocks** — non-capturing blocks transpiled to static C functions
 - **`__block` variables** — promoted to file-scope static
@@ -206,7 +206,7 @@ Zero-cost `static inline` abstraction in `include/platform/`:
 | `oz_platform_zephyr.h`  | `k_mem_slab`, Zephyr atomics, `k_spinlock_t`, `printk` |
 | `oz_platform_host.h`    | malloc-backed slab, C11 `stdatomic`, `printf`  |
 | `oz_platform_types.h`   | Shared type definitions                        |
-| `oz_lock.h`             | OZLock RAII spinlock for `@synchronized`        |
+| `oz_lock.h`             | OZSpinLock RAII spinlock for `@synchronized`    |
 | `oz_assert.h`           | Assertion macros                               |
 
 All PAL functions vanish at `-O1+` — zero runtime overhead.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -135,7 +135,7 @@ Validate transpiled C on real Zephyr kernel via `native_sim` + `ztest` + `twiste
 ### Transpiler Features
 
 - [x] `@property` / `@synthesize` with atomic and strong semantics
-- [x] `@synchronized` via OZLock RAII class
+- [x] `@synchronized` via OZSpinLock RAII class
 - [x] Subscript syntax (`array[i]`, `dict[key]`)
 - [x] Dynamic allocation for OZArray, OZDictionary, OZNumber (literals can reference locals)
 - [x] Compile-time ARC (scope tracking, auto-dealloc, consumed locals, break/continue cleanup)

--- a/docs/OZ_TRANSPILE_EXTRACT_SLAB_PLAN.md
+++ b/docs/OZ_TRANSPILE_EXTRACT_SLAB_PLAN.md
@@ -49,7 +49,7 @@ Committed as `90b2670`.
 - Per-class `alloc/free` in `class_header.h.j2` + `OZ_SLAB_DEFINE` in `class_source.c.j2`
 - `dispatch_free` + `oz_item_pool` moved to `oz_dispatch.h/.c`
 - `oz_mem_slabs.h.j2` + `oz_mem_slabs.c.j2` deleted
-- OZLock special case: `#include "platform/oz_lock.h"` instead of struct generation
+- OZSpinLock special case: `#include "platform/oz_lock.h"` instead of struct generation
 - All golden files, tests, benchmarks updated
 
 ---

--- a/include/oz_sdk/Foundation/Foundation.h
+++ b/include/oz_sdk/Foundation/Foundation.h
@@ -15,4 +15,5 @@
 #import "OZHeap.h"
 #import "OZDefer.h"
 #import "OZLog.h"
+#import "OZSpinLock.h"
 #import "Singleton+Protocol.h"

--- a/include/oz_sdk/Foundation/OZSpinLock.h
+++ b/include/oz_sdk/Foundation/OZSpinLock.h
@@ -1,0 +1,19 @@
+/**
+ * @file OZSpinLock.h
+ * @brief RAII spinlock class for @synchronized support.
+ *
+ * Lightweight ObjC interface that Clang can parse for AST dump.
+ * The transpiler emits a pure-C struct backed by platform spinlock primitives.
+ */
+#pragma once
+#import "OZObject.h"
+
+@interface OZSpinLock : OZObject
+{
+	int _lock;
+	int _key;
+	id _obj;
+}
+- (instancetype)initWithObject:(id)obj;
+- (void)dealloc;
+@end

--- a/include/platform/oz_lock.h
+++ b/include/platform/oz_lock.h
@@ -1,11 +1,11 @@
-/* OZLock — RAII spinlock for @synchronized support */
+/* OZSpinLock — RAII spinlock for @synchronized support */
 #pragma once
 
 #include "oz_platform.h"
 
 struct OZObject;
 
-struct OZLock {
+struct OZSpinLock {
 	struct OZObject base;
 	oz_spinlock_t _lock;
 	oz_spinlock_key_t _key;

--- a/src/OZSpinLock.m
+++ b/src/OZSpinLock.m
@@ -1,0 +1,14 @@
+/* RAII spinlock implementation for @synchronized support. */
+
+#import <Foundation/OZSpinLock.h>
+
+@implementation OZSpinLock
+- (instancetype)initWithObject:(id)obj
+{
+	_obj = obj;
+	return self;
+}
+- (void)dealloc
+{
+}
+@end

--- a/tools/oz_transpile/README.md
+++ b/tools/oz_transpile/README.md
@@ -47,7 +47,7 @@ PYTHONPATH=tools python3 -m oz_transpile --input source.ast.json --outdir genera
 
 - Class/instance methods, inheritance, protocols
 - `@property` / `@synthesize` (atomic, strong, custom getter/setter, ivar names)
-- `@synchronized` (RAII spinlock via OZLock)
+- `@synchronized` (RAII spinlock via OZSpinLock)
 - Subscript syntax (`array[i]`, `dict[key]`)
 - String, boxed, array, and dictionary literals (`@"..."`, `@42`, `@[...]`, `@{...}`)
 - Non-capturing blocks with `__block` file-scope promotion

--- a/tools/oz_transpile/context.py
+++ b/tools/oz_transpile/context.py
@@ -283,7 +283,7 @@ def _build_impl_context(
 
     # Auto-dealloc appended to last method's value
     dealloc_text = ""
-    if not has_user_dealloc and cls.name != "OZLock":
+    if not has_user_dealloc and cls.name != "OZSpinLock":
         buf = StringIO()
         _emit_auto_dealloc(ctx, buf)
         dealloc_text = buf.getvalue()

--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -60,16 +60,16 @@ def _render(env: Environment, template_name: str, context: dict,
     return path
 
 
-def _inject_oz_lock(module: OZModule, root_class: str) -> None:
-    """Add synthetic OZLock class if any @synchronized is used."""
+def _inject_oz_spinlock(module: OZModule, root_class: str) -> None:
+    """Add synthetic OZSpinLock class if any @synchronized is used."""
     counts = _count_alloc_calls(module)
-    if counts.get("OZLock", 0) == 0:
+    if counts.get("OZSpinLock", 0) == 0:
         return
-    if "OZLock" in module.classes:
+    if "OZSpinLock" in module.classes:
         return
     max_id = max((c.class_id for c in module.classes.values()), default=-1)
-    module.classes["OZLock"] = OZClass(
-        name="OZLock",
+    module.classes["OZSpinLock"] = OZClass(
+        name="OZSpinLock",
         superclass=root_class,
         ivars=[
             OZIvar("_lock", OZType("oz_spinlock_t")),
@@ -127,7 +127,7 @@ def _associate_module_items(module: OZModule) -> None:
 """Known foundation class names auto-tagged when --sources is not provided."""
 _FOUNDATION_NAMES = frozenset({
     "OZObject", "OZString", "OZArray", "OZDictionary", "OZNumber", "OZDefer",
-    "OZHeap",
+    "OZHeap", "OZSpinLock",
 })
 
 
@@ -152,7 +152,7 @@ def emit(module: OZModule, outdir: str, pool_sizes: dict[str, int] | None = None
     files = []
 
     _associate_module_items(module)
-    _inject_oz_lock(module, root_class)
+    _inject_oz_spinlock(module, root_class)
     _ensure_foundation_tags(module, root_class)
 
     # Compute pool sizes and item pool count early (needed by per-class templates)
@@ -657,7 +657,7 @@ def _class_source_ctx(ctx: _EmitCtx, stem: str | None = None,
             buf.write("{\n}\n")
         method_bodies.append(buf.getvalue().rstrip("\n"))
 
-    if not has_user_dealloc and cls.name != "OZLock":
+    if not has_user_dealloc and cls.name != "OZSpinLock":
         buf = StringIO()
         _emit_auto_dealloc(ctx, buf)
         val = buf.getvalue()
@@ -847,7 +847,7 @@ def _emit_compound_stmt(node: dict, out: StringIO, ctx: _EmitCtx,
 
 def _emit_synchronized_stmt(node: dict, out: StringIO, ctx: _EmitCtx,
                             indent: int) -> None:
-    """Emit @synchronized(obj) { ... } as OZLock RAII block."""
+    """Emit @synchronized(obj) { ... } as OZSpinLock RAII block."""
     inner = node.get("inner", [])
     if len(inner) < 2:
         return
@@ -868,9 +868,9 @@ def _emit_synchronized_stmt(node: dict, out: StringIO, ctx: _EmitCtx,
 
     ctx.scope_vars.append({})
 
-    out.write(f"{tabs1}struct OZLock *{sync_name} = OZLock_initWithObject("
-              f"OZLock_alloc(), (struct {ctx.root_class} *){obj_buf.getvalue()});\n")
-    ctx.scope_vars[-1][sync_name] = OZType("OZLock *")
+    out.write(f"{tabs1}struct OZSpinLock *{sync_name} = OZSpinLock_initWithObject("
+              f"OZSpinLock_alloc(), (struct {ctx.root_class} *){obj_buf.getvalue()});\n")
+    ctx.scope_vars[-1][sync_name] = OZType("OZSpinLock *")
 
     if body.get("kind") == "CompoundStmt":
         for child in body.get("inner", []):
@@ -2654,7 +2654,7 @@ def _count_alloc_calls(module: OZModule) -> dict[str, int]:
         elif kind == "ObjCBoxedExpr":
             counts["OZNumber"] = counts.get("OZNumber", 0) + 1
         elif kind == "ObjCAtSynchronizedStmt":
-            counts["OZLock"] = counts.get("OZLock", 0) + 1
+            counts["OZSpinLock"] = counts.get("OZSpinLock", 0) + 1
         for child in node.get("inner", []):
             walk(child)
 

--- a/tools/oz_transpile/templates/class_header.h.j2
+++ b/tools/oz_transpile/templates/class_header.h.j2
@@ -14,7 +14,7 @@
 
 {{ td }}
 {% endfor %}
-{% if name == "OZLock" %}
+{% if name == "OZSpinLock" %}
 
 #include "platform/oz_lock.h"
 {% else %}
@@ -48,7 +48,7 @@ int {{ name }}_cDescription_maxLength_(struct {{ name }} *self, char *buf, int m
 {% for proto in method_prototypes %}
 {{ proto }};
 {% endfor %}
-{% if auto_dealloc_proto and name != "OZLock" %}
+{% if auto_dealloc_proto and name != "OZSpinLock" %}
 void {{ name }}_dealloc(struct {{ name }} *self);
 {% endif %}
 {% for decl in extern_decls %}
@@ -118,9 +118,9 @@ static inline struct {{ name }} *{{ name }}_init{{ init.suffix }}({{ init.c_type
 
 {% endfor %}
 {% endif %}
-{% if name == "OZLock" %}
+{% if name == "OZSpinLock" %}
 
-static inline struct OZLock *OZLock_initWithObject(struct OZLock *self,
+static inline struct OZSpinLock *OZSpinLock_initWithObject(struct OZSpinLock *self,
 	struct {{ root_class }} *obj)
 {
 	{{ root_class }}_retain(obj);
@@ -129,11 +129,11 @@ static inline struct OZLock *OZLock_initWithObject(struct OZLock *self,
 	return self;
 }
 
-static inline void OZLock_dealloc(struct OZLock *self)
+static inline void OZSpinLock_dealloc(struct OZSpinLock *self)
 {
 	oz_spin_unlock(&self->_lock, self->_key);
 	{{ root_class }}_release((struct {{ root_class }} *)self->_obj);
-	OZLock_free(self);
+	OZSpinLock_free(self);
 }
 
 {% endif %}

--- a/tools/oz_transpile/tests/fixtures/synchronized_sample.m
+++ b/tools/oz_transpile/tests/fixtures/synchronized_sample.m
@@ -1,4 +1,4 @@
-/* @synchronized sample - tests OZLock RAII transpilation */
+/* @synchronized sample - tests OZSpinLock RAII transpilation */
 
 #import <objc/objc.h>
 

--- a/tools/oz_transpile/tests/test_e2e.py
+++ b/tools/oz_transpile/tests/test_e2e.py
@@ -102,11 +102,11 @@ class TestSynchronizedE2E:
             assert rc == 0
 
             counter_c = open(os.path.join(tmpdir, "Counter_ozm.c")).read()
-            assert "OZLock_initWithObject(OZLock_alloc()" in counter_c
+            assert "OZSpinLock_initWithObject(OZSpinLock_alloc()" in counter_c
             assert "OZObject_release((struct OZObject *)_sync)" in counter_c
 
             dispatch_h = open(os.path.join(tmpdir, "Foundation", "oz_dispatch.h")).read()
-            assert "OZ_CLASS_OZLock" in dispatch_h
+            assert "OZ_CLASS_OZSpinLock" in dispatch_h
 
     def test_synchronized_counter_resets_per_method(self):
         """Both increment and getCount should use _sync (not _sync2)."""
@@ -114,7 +114,7 @@ class TestSynchronizedE2E:
         with tempfile.TemporaryDirectory() as tmpdir:
             main(["--input", ast_file, "--outdir", tmpdir])
             counter_c = open(os.path.join(tmpdir, "Counter_ozm.c")).read()
-            assert counter_c.count("struct OZLock *_sync =") == 2
+            assert counter_c.count("struct OZSpinLock *_sync =") == 2
             assert "_sync2" not in counter_c
 
 

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -1718,7 +1718,7 @@ class TestSynthesizedPropertyEmission:
 # ===========================================================================
 
 class TestSynchronized:
-    """Tests for @synchronized -> OZLock RAII emission."""
+    """Tests for @synchronized -> OZSpinLock RAII emission."""
 
     def test_basic_synchronized(self):
         """@synchronized(self) { self->_count = 1; }"""
@@ -1738,13 +1738,13 @@ class TestSynchronized:
 @end
 """)
         content = out["Foo_ozm.c"]
-        assert "struct OZLock *_sync = OZLock_initWithObject(" in content
-        assert "OZLock_alloc()" in content
+        assert "struct OZSpinLock *_sync = OZSpinLock_initWithObject(" in content
+        assert "OZSpinLock_alloc()" in content
         assert "(struct OZObject *)self" in content
         assert "OZObject_release((struct OZObject *)_sync);" in content
 
-    def test_synchronized_oz_lock_slab(self):
-        """OZLock slab generated when @synchronized is used."""
+    def test_synchronized_oz_spinlock_slab(self):
+        """OZSpinLock slab generated when @synchronized is used."""
         _, out = clang_emit("""\
 #import <Foundation/OZObject.h>
 @interface Foo : OZObject
@@ -1757,7 +1757,7 @@ class TestSynchronized:
 @end
 """)
         dispatch_h = out["Foundation/oz_dispatch.h"]
-        assert "OZ_CLASS_OZLock" in dispatch_h
+        assert "OZ_CLASS_OZSpinLock" in dispatch_h
 
     def test_synchronized_early_return(self):
         """Early return inside @synchronized releases the lock."""
@@ -1795,11 +1795,11 @@ class TestSynchronized:
 @end
 """)
         content = out["Foo_ozm.c"]
-        assert "struct OZLock *_sync = " in content
-        assert "struct OZLock *_sync2 = " in content
+        assert "struct OZSpinLock *_sync = " in content
+        assert "struct OZSpinLock *_sync2 = " in content
 
-    def test_no_oz_lock_without_synchronized(self):
-        """OZLock not injected when no @synchronized used."""
+    def test_no_oz_spinlock_without_synchronized(self):
+        """OZSpinLock not injected when no @synchronized used."""
         _, out = clang_emit("""\
 #import <Foundation/OZObject.h>
 @interface Foo : OZObject
@@ -1810,7 +1810,7 @@ class TestSynchronized:
 @end
 """)
         dispatch_h = out["Foundation/oz_dispatch.h"]
-        assert "OZLock" not in dispatch_h
+        assert "OZSpinLock" not in dispatch_h
 
     def test_synchronized_with_ivar_obj(self):
         """@synchronized(_mutex) uses ivar expression."""
@@ -1909,11 +1909,11 @@ class TestSynchronized:
 @end
 """)
         content = out["Foo_ozm.c"]
-        assert "struct OZLock *_sync = " in content
-        assert "struct OZLock *_sync2 = " in content
+        assert "struct OZSpinLock *_sync = " in content
+        assert "struct OZSpinLock *_sync2 = " in content
 
-    def test_dispatch_free_includes_oz_lock(self):
-        """dispatch_free switch includes OZLock case."""
+    def test_dispatch_free_includes_oz_spinlock(self):
+        """dispatch_free switch includes OZSpinLock case."""
         _, out = clang_emit("""\
 #import <Foundation/OZObject.h>
 @interface Foo : OZObject
@@ -1926,7 +1926,7 @@ class TestSynchronized:
 @end
 """)
         dispatch_c = out["Foundation/oz_dispatch.c"]
-        assert "case OZ_CLASS_OZLock: OZLock_free(" in dispatch_c
+        assert "case OZ_CLASS_OZSpinLock: OZSpinLock_free(" in dispatch_c
 
     def test_synchronized_compiles_on_host(self):
         """Generated @synchronized code compiles with GCC on host."""


### PR DESCRIPTION
## Summary
- Closes #99 (OZ-066: Rename OZLock to OZSpinLock)
- Promotes OZSpinLock to a proper Foundation class with ObjC header + implementation
- Renames struct in platform header, updates transpiler and all tests

## Changes
- `include/oz_sdk/Foundation/OZSpinLock.h` — new ObjC interface for Clang AST
- `src/OZSpinLock.m` — new ObjC implementation (stub bodies)
- `include/oz_sdk/Foundation/Foundation.h` — added OZSpinLock import
- `include/platform/oz_lock.h` — struct OZLock → OZSpinLock
- `tools/oz_transpile/emit.py` — renamed inject/emit functions, updated _FOUNDATION_NAMES
- `tools/oz_transpile/context.py` — dealloc skip check updated
- `tools/oz_transpile/templates/class_header.h.j2` — all OZLock → OZSpinLock
- Tests and docs updated across 6 files

## Embedded Considerations
- Footprint: no change — same static inline functions
- Performance: no change — zero-cost abstractions unchanged
- Reliability: no change — cosmetic rename only

## Test Plan
- [x] `just test-transpiler` passes (467/467)
- [x] `just test-behavior` passes (41/41)
- [x] `just test` full suite passes (11/11 twister)