### PR TITLE
fix(transpiler): emit enum type_defs in patched-source path (OZ-069)

### DIFF
--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -3068,6 +3068,18 @@ def _emit_patched_source(source_path: Path, module: OZModule,
     out.write(f'#include "{stem}_ozh.h"\n')
     for dep_stem in dep_stems:
         out.write(f'#include "{dep_stem}_ozh.h"\n')
+
+    # OZ-069: emit enum type_defs needed by the source but not in headers.
+    const_map = _type_def_constant_map(module)
+    header_td: list[str] = []
+    for c in module.classes.values():
+        for td in _header_type_defs_for_class(c, module):
+            if td not in header_td:
+                header_td.append(td)
+    src_type_defs = _scan_source_type_defs([rendered], const_map, header_td)
+    for td in src_type_defs:
+        out.write(f"\n{td}\n")
+
     for cls in classes:
         pc = pool_count_fn(cls.name) if pool_count_fn else 1
         if not isinstance(pc, int) or pc < 1:
@@ -3154,6 +3166,18 @@ def _emit_patched_orphan_source(orphan: OrphanSource, module: OZModule,
     out.write('#include "oz_dispatch.h"\n')
     for dep_stem in dep_stems:
         out.write(f'#include "{dep_stem}_ozh.h"\n')
+
+    # OZ-069: emit enum type_defs needed by orphan source.
+    const_map = _type_def_constant_map(module)
+    header_td: list[str] = []
+    for c in module.classes.values():
+        for td in _header_type_defs_for_class(c, module):
+            if td not in header_td:
+                header_td.append(td)
+    src_type_defs = _scan_source_type_defs([rendered], const_map, header_td)
+    for td in src_type_defs:
+        out.write(f"\n{td}\n")
+
     # Emit orphan statics not already preserved in the roundtrip
     for sv in orphan.statics:
         if sv.name not in orphan_static_names:


### PR DESCRIPTION
## Summary
- Closes #110 (OZ-069: follow-up — patched-source path)
- The initial fix (#111) only covered the Jinja2 template path
- User classes with `source_path` use the patched-source roundtrip path (`_emit_patched_source`), which was missing enum injection
- Adds `_scan_source_type_defs()` calls to both `_emit_patched_source()` and `_emit_patched_orphan_source()`

## Verified
- px-app builds and runs with WA-007 workaround fully removed (enums in headers, no duplicates in .m files)
- `just test-transpiler` passes (484 tests)
- `just test-behavior` passes (42 tests)
- `just test` full twister suite passes (11/11)