### PR TITLE
fix(transpiler): deduplicate string constants across functions (OZ-071)

### DIFF
--- a/tools/oz_transpile/context.py
+++ b/tools/oz_transpile/context.py
@@ -88,6 +88,10 @@ def build_source_context(
 
     source_dir = source_path.parent
 
+    # Shared dedup state across all functions/methods in the same file
+    shared_dedup: dict[str, str] = {}
+    shared_strings: list[str] = []
+
     for child in tree.root_node.children:
         text = source[child.start_byte:child.end_byte].decode()
 
@@ -95,6 +99,7 @@ def build_source_context(
             _build_impl_context(
                 child, source, context, class_map, module,
                 root_class, has_item_pool, static_names,
+                shared_dedup=shared_dedup,
             )
 
         elif child.type == "preproc_include":
@@ -112,7 +117,9 @@ def build_source_context(
                 buf = StringIO()
                 _emit_transpiled_function(func, module, buf, root_class,
                                           has_item_pool,
-                                          source_bytes=source)
+                                          source_bytes=source,
+                                          shared_dedup=shared_dedup,
+                                          shared_strings=shared_strings)
                 context[key] = buf.getvalue()
             else:
                 context[key] = text
@@ -136,6 +143,10 @@ def build_source_context(
                     continue
             context[key] = text
 
+    # Store shared string constants from C functions for file-level emission
+    if shared_strings:
+        context["__shared_constants__"] = shared_strings
+
     return context
 
 
@@ -144,6 +155,7 @@ def _build_impl_context(
     class_map: dict[str, OZClass], module: OZModule,
     root_class: str, has_item_pool: bool,
     static_names: set[str] | None = None,
+    shared_dedup: dict[str, str] | None = None,
 ) -> None:
     """Build context entries for methods inside @implementation."""
     from oz_transpile.emit import (
@@ -170,6 +182,8 @@ def _build_impl_context(
 
     ctx = _EmitCtx(cls=cls, module=module, root_class=root_class,
                    has_item_pool=has_item_pool, source_bytes=source)
+    if shared_dedup is not None:
+        ctx._string_dedup = shared_dedup
     is_root = cls.name == root_class
     _root_skip_sels = {"retain", "release", "retainCount",
                        "isEqual:", "cDescription:maxLength:"}

--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -216,9 +216,11 @@ def emit(module: OZModule, outdir: str, pool_sizes: dict[str, int] | None = None
         else:
             source_tmpl = env.get_template("class_source.c.j2")
             source_parts = []
+            shared_dedup: dict[str, str] = {}
             for cls in classes:
                 ctx = _EmitCtx(cls=cls, module=module, root_class=root_class,
                                has_item_pool=_has_item_pool)
+                ctx._string_dedup = shared_dedup
                 source_parts.append(
                     source_tmpl.render(**_class_source_ctx(
                         ctx, stem,
@@ -1504,7 +1506,9 @@ def _emit_block_expr(node: dict, out: StringIO, ctx: _EmitCtx) -> None:
     if line is not None and col is not None:
         func_name = f"_oz_block_L{line}_C{col}"
     else:
-        func_name = f"_oz_block_{len(ctx.block_functions)}"
+        ctx.module.diagnostics.append(
+            "warning: BlockExpr without source location")
+        func_name = f"_oz_block_L0_C{len(ctx.block_functions)}"
 
     # Build param string
     param_parts = []
@@ -1823,7 +1827,9 @@ def _emit_expr(node: dict, out: StringIO, ctx: _EmitCtx) -> None:
             if line is not None and col is not None:
                 name = f"_oz_str_L{line}_C{col}"
             else:
-                name = f"_oz_str_{len(ctx._string_dedup)}"
+                ctx.module.diagnostics.append(
+                    "warning: ObjCStringLiteral without source location")
+                name = f"_oz_str_L0_C{len(ctx._string_dedup)}"
             ctx._string_dedup[val] = name
             ctx.string_constants.append(
                 f"static struct OZString {name} = {{"
@@ -2976,11 +2982,17 @@ def _emit_transpiled_function(func: OZFunction, module: OZModule,
                                out: StringIO,
                                root_class: str,
                                has_item_pool: bool,
-                               source_bytes: bytes | None = None) -> None:
+                               source_bytes: bytes | None = None,
+                               shared_dedup: dict[str, str] | None = None,
+                               shared_strings: list[str] | None = None) -> None:
     """Emit a transpiled C function (replacing one that contained ObjC)."""
     dummy_cls = OZClass(name="__patched__")
     ctx = _EmitCtx(cls=dummy_cls, module=module, root_class=root_class,
                    has_item_pool=has_item_pool, source_bytes=source_bytes)
+    if shared_dedup is not None:
+        ctx._string_dedup = shared_dedup
+    if shared_strings is not None:
+        ctx.string_constants = shared_strings
     ctx.method = None
     ctx.scope_vars = []
     ctx.consumed_vars = set()
@@ -3001,10 +3013,12 @@ def _emit_transpiled_function(func: OZFunction, module: OZModule,
     else:
         body_buf.write("{\n}\n")
 
-    # Emit string constants and block functions before the function body
-    for sc in ctx.string_constants:
-        out.write(sc)
-        out.write("\n")
+    # Emit string constants and block functions before the function body.
+    # When using shared lists the caller emits them once for the whole file.
+    if shared_strings is None:
+        for sc in ctx.string_constants:
+            out.write(sc)
+            out.write("\n")
     for bf in ctx.block_functions:
         out.write(bf)
         out.write("\n\n")
@@ -3041,6 +3055,9 @@ def _emit_patched_source(source_path: Path, module: OZModule,
     emitted_includes = {f'#include "{stem}_ozh.h"'}
     for dep_stem in dep_stems:
         emitted_includes.add(f'#include "{dep_stem}_ozh.h"')
+
+    # Extract shared constants before rendering (not a template variable)
+    shared_sc = context.pop("__shared_constants__", None)
 
     # Filter include context values to avoid duplicates
     # Normalize whitespace for comparison: "#include  <x>" -> "#include <x>"
@@ -3087,6 +3104,13 @@ def _emit_patched_source(source_path: Path, module: OZModule,
         out.write(f"\nOZ_SLAB_DEFINE(oz_slab_{cls.name}, "
                   f"sizeof(struct {cls.name}), {pc}, 4);\n")
 
+    # Emit shared string constants from C functions
+    if shared_sc:
+        out.write("\n")
+        for sc in shared_sc:
+            out.write(sc)
+            out.write("\n")
+
     out.write(rendered)
     return out.getvalue()
 
@@ -3122,6 +3146,9 @@ def _emit_patched_orphan_source(orphan: OrphanSource, module: OZModule,
         )
     finally:
         module.functions = saved_funcs
+
+    # Extract shared constants before rendering (not a template variable)
+    shared_sc = context.pop("__shared_constants__", None)
 
     # Compute dependency includes: all class headers from the module
     dep_stems = sorted({_header_stem(cls) for cls in module.classes.values()})
@@ -3185,6 +3212,14 @@ def _emit_patched_orphan_source(orphan: OrphanSource, module: OZModule,
         decl_str = sv.oz_type.c_param_decl(sv.name)
         init = f" = {sv.init_value}" if sv.init_value is not None else ""
         out.write(f"static {decl_str}{init};\n")
+
+    # Emit shared string constants from C functions
+    if shared_sc:
+        out.write("\n")
+        for sc in shared_sc:
+            out.write(sc)
+            out.write("\n")
+
     out.write(rendered)
     return out.getvalue()
 

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -3299,6 +3299,26 @@ class TestEmitEdgeCases:
             src = open(os.path.join(tmpdir, "Foo_ozm.c")).read()
             assert "_oz_str_L10_C5" in src
 
+    def test_string_dedup_across_c_functions(self):
+        """OZ-071: same string literal in two C functions must not produce
+        duplicate static definitions (redefinition error)."""
+        _, out = clang_emit_patched("""\
+#import <Foundation/OZObject.h>
+#import <Foundation/OZString.h>
+@interface Foo : OZObject
+- (void)greet;
+@end
+@implementation Foo
+- (void)greet { OZString *s = @"key"; }
+@end
+void other_fn(void) {
+    OZString *k = @"key";
+}
+""", stem="Foo")
+        src = out["Foo_ozm.c"]
+        assert src.count("static struct OZString _oz_str_") == 1, \
+            f"Expected 1 string constant, got: {src.count('static struct OZString _oz_str_')}"
+
     def test_explicit_release_prevents_double_release(self):
         """OZ-041: explicit [obj release] must suppress ARC auto-release."""
         _, out = clang_emit("""\


### PR DESCRIPTION
## Summary
- Closes #118 (OZ-071: Duplicate _oz_str_N when same string literal appears in multiple functions)
- Shares `_string_dedup` dict across all functions/methods in the same output file to prevent duplicate `static struct OZString` definitions

## Changes
- `context.py` — Create shared `_string_dedup` dict in `build_source_context`, pass to `_build_impl_context` and `_emit_transpiled_function`
- `emit.py` — Accept `shared_dedup`/`shared_strings` in `_emit_transpiled_function`; emit shared string constants in file preamble; share dedup across classes in template path; warn on missing loc info
- `test_emit.py` — Add regression test: same `@"key"` in ObjC method + C function produces single static

## Embedded Considerations
- Footprint: reduced — duplicate string constants eliminated
- Performance: no change
- Reliability: no change

## Test Plan
- [x] `just test-transpiler` passes (485 tests)
- [x] `just test-behavior` passes (42 tests)
- [x] Regression test added for OZ-071
- [x] `just test` full suite passes (11/11 twister)