### PR TITLE
fix(build): add OZTimer.m to CMake transpile pipeline

### DIFF
--- a/cmake/oz_transpile.cmake
+++ b/cmake/oz_transpile.cmake
@@ -47,10 +47,11 @@ function(objz_transpile_sources target)
     set(_oz_array_src ${_mod}/src/OZArray.m)
     set(_oz_dict_src ${_mod}/src/OZDictionary.m)
     set(_oz_q31_src ${_mod}/src/OZQ31.m)
+    set(_oz_timer_src ${_mod}/src/OZTimer.m)
     # Prepend so transpiler stubs (assert.h, Foundation/, etc.) take priority
     list(PREPEND _ast_flags -I${_oz_inc_dir})
-    list(PREPEND _sources ${_oz_q31_src} ${_oz_dict_src} ${_oz_array_src}
-                          ${_oz_string_src} ${_oz_root_src})
+    list(PREPEND _sources ${_oz_timer_src} ${_oz_q31_src} ${_oz_dict_src}
+                          ${_oz_array_src} ${_oz_string_src} ${_oz_root_src})
     if(CONFIG_OBJZ_HEAP)
         set(_oz_heap_src ${_mod}/src/OZHeap.m)
         list(PREPEND _sources ${_oz_heap_src})

--- a/include/oz_sdk/Foundation/OZTimer.h
+++ b/include/oz_sdk/Foundation/OZTimer.h
@@ -11,6 +11,22 @@
 #import "OZObject.h"
 #include <zephyr/kernel.h>
 
+/**
+ * @brief Bridge block void* to function pointer for k_timer_init.
+ *
+ * ARC forbids direct block-to-fptr cast; void*-to-fptr is unrestricted.
+ * Used by OZTimer init to pass block callbacks to k_timer_init.
+ */
+#ifndef __OZ_TIMER_SETUP_DEFINED
+#define __OZ_TIMER_SETUP_DEFINED
+static inline void __oz_timer_setup(struct k_timer *t, void *exp,
+                                     void *stp, void *ud)
+{
+	k_timer_init(t, (k_timer_expiry_t)exp, (k_timer_stop_t)stp);
+	k_timer_user_data_set(t, ud);
+}
+#endif
+
 @interface OZTimer : OZObject {
 	struct k_timer _timer;
 	void (^_expiryBlock)(struct k_timer *);

--- a/tests/behavior/include/zephyr_stubs/zephyr/kernel.h
+++ b/tests/behavior/include/zephyr_stubs/zephyr/kernel.h
@@ -51,15 +51,17 @@ static inline void *k_timer_user_data_get(struct k_timer *timer)
         return timer->user_data;
 }
 
-/*
- * __oz_timer_setup — bridges void* to function pointer for k_timer_init.
- * ARC forbids direct block-to-fptr cast; void*-to-fptr is unrestricted.
+/**
+ * @brief Bridge void* to function pointer for k_timer_init (ARC workaround).
  */
+#ifndef __OZ_TIMER_SETUP_DEFINED
+#define __OZ_TIMER_SETUP_DEFINED
 static inline void __oz_timer_setup(struct k_timer *t, void *exp,
                                      void *stp, void *ud)
 {
         k_timer_init(t, (k_timer_expiry_t)exp, (k_timer_stop_t)stp);
         k_timer_user_data_set(t, ud);
 }
+#endif
 
 #endif /* ZEPHYR_KERNEL_STUB_H */


### PR DESCRIPTION
## Summary
- OZTimer.m was missing from oz_transpile.cmake Foundation sources
- __oz_timer_setup helper was only in test stub, not available for Zephyr builds
- Fixes OZTimer integration in downstream projects (px-keyboard)

## Changes
- **oz_transpile.cmake**: prepend OZTimer.m to Foundation source list
- **OZTimer.h**: add `__oz_timer_setup` with `#ifndef` guard
- **zephyr/kernel.h stub**: restore helper with matching guard

## Test Plan
- [x] `just test-transpiler` passes (496)
- [x] `just test-behavior` passes (45)