### PR TITLE
fix(transpiler): unwrap ARC casts in PseudoObjectExpr (OZ-080)

### DIFF
--- a/include/oz_sdk/Foundation/OZObject.h
+++ b/include/oz_sdk/Foundation/OZObject.h
@@ -49,6 +49,7 @@ __attribute__((objc_root_class))
 }
 + (instancetype)alloc;
 + (instancetype)allocWithHeap:(id)heap;
++ (Class)class;
 - (instancetype)init;
 - (void)dealloc;
 - (BOOL)isEqual:(id)anObject;

--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -2023,13 +2023,23 @@ def _emit_expr(node: dict, out: StringIO, ctx: _EmitCtx) -> None:
         return
 
     if kind == "PseudoObjectExpr":
-        # ObjC subscript: inner[0] is ObjCSubscriptRefExpr (syntactic),
+        # ObjC property/subscript: inner[0] is the syntactic ref,
         # last ObjCMessageExpr child is the lowered call.
+        # ARC may wrap it in ImplicitCastExpr/ExprWithCleanups.
         inner = node.get("inner", [])
         if inner:
             msg = None
             for child in reversed(inner):
-                if child.get("kind") == "ObjCMessageExpr":
+                unwrapped = child
+                while unwrapped.get("kind") in (
+                    "ImplicitCastExpr", "ExprWithCleanups",
+                ):
+                    sub = unwrapped.get("inner", [])
+                    if sub:
+                        unwrapped = sub[0]
+                    else:
+                        break
+                if unwrapped.get("kind") == "ObjCMessageExpr":
                     msg = child
                     break
             _emit_expr(msg if msg else inner[0], out, ctx)

--- a/tools/oz_transpile/tests/conftest.py
+++ b/tools/oz_transpile/tests/conftest.py
@@ -48,7 +48,7 @@ def clang_collect(source, *, extra_files=None):
         result = subprocess.run(
             [
                 "clang", "-Xclang", "-ast-dump=json", "-fsyntax-only",
-                "-fobjc-runtime=macosx", "-fblocks",
+                "-fobjc-runtime=macosx", "-fobjc-arc", "-fblocks",
                 "-I", OZ_SDK_DIR, "-I", tmpdir, src_path,
             ],
             capture_output=True,
@@ -115,7 +115,7 @@ def clang_emit_patched(source, stem, **kwargs):
         result = subprocess.run(
             [
                 "clang", "-Xclang", "-ast-dump=json", "-fsyntax-only",
-                "-fobjc-runtime=macosx", "-fblocks",
+                "-fobjc-runtime=macosx", "-fobjc-arc", "-fblocks",
                 "-I", OZ_SDK_DIR, "-I", tmpdir, src_path,
             ],
             capture_output=True,

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -303,7 +303,7 @@ class TestBodyEmission:
 @end
 @implementation OZLed
 - (instancetype)initWithPin:(int)pin {
-    [super init];
+    self = [super init];
     return self;
 }
 @end
@@ -561,7 +561,6 @@ class TestARCAutoDealloc:
 @implementation Holder
 - (void)dealloc {
     _count = 42;
-    [super dealloc];
 }
 @end
 """)
@@ -1578,6 +1577,33 @@ enum my_status { MY_OK = 0, MY_ERR };
 """)
         src = out["Foo_ozm.c"]
         assert "OZArray_objectAtIndexedSubscript_" in src
+
+    def test_pseudo_object_expr_property_on_method_return(self):
+        """OZ-080: [obj method].property must emit getter wrapping the call."""
+        _, out = clang_emit("""\
+#import <Foundation/OZObject.h>
+#import <Foundation/OZHeap.h>
+@interface App : OZObject
+@property(readonly, nonatomic) OZHeap *heap;
++ (instancetype)sharedInstance;
+@end
+@implementation App
+static App *app;
+@synthesize heap = _heap;
++ (void)initialize { app = [[App alloc] init]; }
++ (instancetype)sharedInstance { return app; }
+- (id)init { self = [super init]; return self; }
+@end
+@interface Tester : OZObject
+@end
+@implementation Tester
+- (void)run {
+    OZHeap *h = [App sharedInstance].heap;
+}
+@end
+""")
+        src = out["Tester_ozm.c"]
+        assert "App_heap(App_cls_sharedInstance())" in src
 
 
 # ===========================================================================
@@ -3317,8 +3343,8 @@ void other_fn(void) {
         assert src.count("static struct OZString _oz_str_") == 1, \
             f"Expected 1 string constant, got: {src.count('static struct OZString _oz_str_')}"
 
-    def test_explicit_release_prevents_double_release(self):
-        """OZ-041: explicit [obj release] must suppress ARC auto-release."""
+    def test_arc_scope_exit_releases_local(self):
+        """OZ-041: ARC auto-release emits exactly one release at scope exit."""
         _, out = clang_emit("""\
 #import <Foundation/OZObject.h>
 @interface Foo : OZObject
@@ -3327,7 +3353,6 @@ void other_fn(void) {
 @implementation Foo
 - (void)doWork {
     OZObject *obj = [[OZObject alloc] init];
-    [obj release];
 }
 @end
 """)


### PR DESCRIPTION
## Summary
- Closes #150 (OZ-080: Property access on method return value dropped)
- PseudoObjectExpr handler now unwraps `ImplicitCastExpr`/`ExprWithCleanups` when searching for the lowered getter `ObjCMessageExpr`

## Changes
- `emit.py`: unwrap transparent ARC wrapper nodes in PseudoObjectExpr reverse search
- `conftest.py`: add `-fobjc-arc` to match real build Clang flags
- `test_emit.py`: add OZ-080 regression test; fix 3 ARC-incompatible test patterns
- `OZObject.h`: add `+class` declaration for ARC compatibility

## Embedded Considerations
- Footprint: no change
- Performance: no change
- Reliability: fixes incorrect codegen that caused GCC type error

## Test Plan
- [x] `just test-transpiler` passes (500/500)
- [x] `just test-behavior` passes (46/46)
- [x] Regression test added for OZ-080
- [x] `just test` — 9/11 pass (2 pre-existing failures, heap_alloc now fixed)
- [x] `just run` on heap_alloc — runtime verified in QEMU