### PR TITLE
fix(transpiler): handle const-qualified pointer in for-in cast (OZ-081)

### DIFF
--- a/tools/oz_transpile/model.py
+++ b/tools/oz_transpile/model.py
@@ -98,6 +98,8 @@ class OZType:
 
     _NON_OBJECT_TYPES = frozenset({"BOOL"})
 
+    _PTR_QUALIFIERS = ("const", "volatile", "restrict")
+
     @property
     def is_object(self) -> bool:
         qt = self._strip_qualifiers()
@@ -105,8 +107,12 @@ class OZType:
             return False
         if qt == "id" or qt == "instancetype":
             return True
-        if qt.endswith("*") and qt[0].isupper():
-            name = qt.rstrip(" *")
+        bare = qt
+        for q in OZType._PTR_QUALIFIERS:
+            if bare.endswith(q):
+                bare = bare[:-len(q)].rstrip()
+        if bare.endswith("*") and bare[0].isupper():
+            name = bare.rstrip(" *")
             return name not in OZType._NON_OBJECT_TYPES
         return False
 
@@ -128,8 +134,10 @@ class OZType:
         if qt == "id *":
             return "struct OZObject **"
         if self.is_object:
-            name = qt.rstrip(" *")
-            return f"struct {name} *"
+            star = qt.index("*")
+            name = qt[:star].rstrip()
+            suffix = qt[star + 1:].strip()
+            return f"struct {name} *{suffix}" if suffix else f"struct {name} *"
         return qt
 
     @staticmethod

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -3271,6 +3271,27 @@ class TestEmitEdgeCases:
         assert "OZ_PROTOCOL_SEND_next" in src
         assert "item" in src
 
+    def test_forin_typed_var_struct_prefix(self):
+        """OZ-081: for-in with typed variable must emit struct prefix in cast."""
+        _, out = clang_emit("""\
+#import <Foundation/OZObject.h>
+@interface Bar : OZObject
+@end
+@implementation Bar
+@end
+@interface Foo : OZObject
+- (void)iterate;
+@end
+@implementation Foo
+- (void)iterate {
+    for (Bar *b in self) {}
+}
+@end
+""")
+        src = out["Foo_ozm.c"]
+        assert "(struct Bar *" in src
+        assert "Bar *b" in src or "Bar *const" in src
+
     def test_string_dedup_unique_across_methods(self):
         """OZ-039: different string literals in separate methods must get
         unique constant names (no _oz_str_N redefinition)."""

--- a/tools/oz_transpile/tests/test_model.py
+++ b/tools/oz_transpile/tests/test_model.py
@@ -142,6 +142,17 @@ class TestOZType:
         t = OZType("__strong OZArray<OZString *> *")
         assert t.generic_params == ["OZString *"]
 
+    def test_const_pointer_is_object(self):
+        """OZ-081: for-in loop var qualType ends with *const."""
+        t = OZType("OZQ31 *const")
+        assert t.is_object
+        assert t.c_type == "struct OZQ31 *const"
+
+    def test_const_pointer_with_space(self):
+        t = OZType("OZQ31 * const")
+        assert t.is_object
+        assert t.c_type == "struct OZQ31 *const"
+
 
 class TestOZParam:
     def test_construction(self):


### PR DESCRIPTION
## Summary
- Closes #148 (OZ-081: for-in loop cast missing struct keyword)
- `OZType.is_object` and `c_type` now handle trailing pointer qualifiers (`const`/`volatile`/`restrict`) so `OZQ31 *const` correctly emits `struct OZQ31 *const`

## Changes
- `model.py`: `is_object` strips trailing pointer qualifiers before the `endswith("*")` check; `c_type` preserves them after the `struct` prefix
- `test_model.py`: two unit tests for `*const` variants
- `test_emit.py`: emit-level regression test for typed for-in variable

## Embedded Considerations
- Footprint: no change
- Performance: no change
- Reliability: fixes GCC compile error on for-in with typed variables

## Test Plan
- [x] `just test-transpiler` passes (503/503)
- [x] `just test-behavior` passes (46/46)
- [x] Regression test added for OZ-081