### PR TITLE
fix(transpiler): preserve non-ObjC header content (OZ-090)

### DIFF
--- a/tests/behavior/cases/regression/issue_090_header_preservation.h
+++ b/tests/behavior/cases/regression/issue_090_header_preservation.h
@@ -1,0 +1,46 @@
+/*
+ * Companion header for regression test issue #090.
+ *
+ * All non-ObjC content below must survive transpilation and appear
+ * in the generated _ozh.h header.
+ */
+#import "OZTestBase.h"
+
+/* --- enum not used by @interface --- */
+enum sensor_state {
+	SENSOR_IDLE = 0,
+	SENSOR_SAMPLING,
+	SENSOR_ERROR,
+};
+
+/* --- struct not used by @interface --- */
+struct sensor_msg {
+	enum sensor_state state;
+	int value;
+};
+
+/* --- union not used by @interface --- */
+union sensor_data {
+	int raw;
+	float calibrated;
+};
+
+/* --- #define constant --- */
+#define SENSOR_MAX_CHANNELS 8
+
+/* --- function-like #define macro --- */
+#define SENSOR_CLAMP(v, lo, hi) ((v) < (lo) ? (lo) : (v) > (hi) ? (hi) : (v))
+
+/* --- static inline helper --- */
+static inline int sensor_scale(int raw, int factor)
+{
+	return raw * factor;
+}
+
+/* --- ObjC interface (should NOT appear as verbatim) --- */
+@interface SensorCtrl : OZObject {
+	int _reading;
+}
+- (int)reading;
+- (void)setReading:(int)val;
+@end

--- a/tests/behavior/cases/regression/issue_090_header_preservation.m
+++ b/tests/behavior/cases/regression/issue_090_header_preservation.m
@@ -1,0 +1,20 @@
+/*
+ * Regression test for issue #090.
+ *
+ * Bug: Transpiler drops struct/union/enum/macro definitions from companion
+ *      headers when they are not referenced by ObjC interface members.
+ * Fix: Scan companion .h with tree-sitter; preserve all non-ObjC content
+ *      as header_verbatim_lines emitted in the generated _ozh.h.
+ * Commit: TBD
+ */
+/* oz-pool: SensorCtrl=2 */
+#import "issue_090_header_preservation.h"
+
+@implementation SensorCtrl
+- (int)reading {
+	return _reading;
+}
+- (void)setReading:(int)val {
+	_reading = val;
+}
+@end

--- a/tests/behavior/cases/regression/issue_090_header_preservation_test.c
+++ b/tests/behavior/cases/regression/issue_090_header_preservation_test.c
@@ -1,0 +1,84 @@
+/*
+ * Behavior test for issue #090: all non-ObjC header content must compile
+ * and work correctly after transpilation.
+ */
+#include "unity.h"
+#include "SensorCtrl_ozh.h"
+
+/* ---- enum preserved ---- */
+void test_enum_values_accessible(void)
+{
+	enum sensor_state s = SENSOR_IDLE;
+	TEST_ASSERT_EQUAL_INT(0, s);
+	s = SENSOR_SAMPLING;
+	TEST_ASSERT_EQUAL_INT(1, s);
+	s = SENSOR_ERROR;
+	TEST_ASSERT_EQUAL_INT(2, s);
+}
+
+/* ---- struct preserved ---- */
+void test_struct_usable(void)
+{
+	struct sensor_msg msg;
+	msg.state = SENSOR_SAMPLING;
+	msg.value = 42;
+	TEST_ASSERT_EQUAL_INT(SENSOR_SAMPLING, msg.state);
+	TEST_ASSERT_EQUAL_INT(42, msg.value);
+}
+
+/* ---- union preserved ---- */
+void test_union_usable(void)
+{
+	union sensor_data d;
+	d.raw = 100;
+	TEST_ASSERT_EQUAL_INT(100, d.raw);
+	d.calibrated = 3.14f;
+	TEST_ASSERT_FLOAT_WITHIN(0.01f, 3.14f, d.calibrated);
+}
+
+/* ---- #define constant preserved ---- */
+void test_define_constant_accessible(void)
+{
+	TEST_ASSERT_EQUAL_INT(8, SENSOR_MAX_CHANNELS);
+	int arr[SENSOR_MAX_CHANNELS];
+	arr[0] = 1;
+	arr[7] = 99;
+	TEST_ASSERT_EQUAL_INT(1, arr[0]);
+	TEST_ASSERT_EQUAL_INT(99, arr[7]);
+}
+
+/* ---- function-like #define macro preserved ---- */
+void test_function_macro_works(void)
+{
+	TEST_ASSERT_EQUAL_INT(5, SENSOR_CLAMP(3, 5, 10));
+	TEST_ASSERT_EQUAL_INT(7, SENSOR_CLAMP(7, 5, 10));
+	TEST_ASSERT_EQUAL_INT(10, SENSOR_CLAMP(15, 5, 10));
+}
+
+/* ---- static inline function preserved ---- */
+void test_static_inline_function_works(void)
+{
+	TEST_ASSERT_EQUAL_INT(30, sensor_scale(10, 3));
+	TEST_ASSERT_EQUAL_INT(0, sensor_scale(0, 100));
+	TEST_ASSERT_EQUAL_INT(-6, sensor_scale(-2, 3));
+}
+
+/* ---- ObjC class still works alongside preserved content ---- */
+void test_class_methods_work(void)
+{
+	struct SensorCtrl *ctrl = SensorCtrl_alloc();
+	TEST_ASSERT_NOT_NULL(ctrl);
+	SensorCtrl_setReading_(ctrl, 123);
+	TEST_ASSERT_EQUAL_INT(123, SensorCtrl_reading(ctrl));
+	OZObject_release((struct OZObject *)ctrl);
+}
+
+/* ---- struct and enum interact correctly ---- */
+void test_struct_enum_interaction(void)
+{
+	struct sensor_msg msg;
+	msg.state = SENSOR_ERROR;
+	msg.value = sensor_scale(5, SENSOR_MAX_CHANNELS);
+	TEST_ASSERT_EQUAL_INT(SENSOR_ERROR, msg.state);
+	TEST_ASSERT_EQUAL_INT(40, msg.value);
+}

--- a/tests/behavior/test_regression.py
+++ b/tests/behavior/test_regression.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from conftest import discover_behavior_tests
+
+REGRESSION_TESTS = list(discover_behavior_tests("regression"))
+
+
+@pytest.mark.parametrize("m_file", REGRESSION_TESTS)
+def test_regression(m_file, compile_and_run):
+    result = compile_and_run(m_file)
+    assert result.returncode == 0, (
+        f"FAILED: {m_file.name}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/tools/oz_transpile/collect.py
+++ b/tools/oz_transpile/collect.py
@@ -81,6 +81,9 @@ def merge_modules(modules: list[OZModule]) -> OZModule:
                 for line in cls.verbatim_lines:
                     if line not in existing.verbatim_lines:
                         existing.verbatim_lines.append(line)
+                for line in cls.header_verbatim_lines:
+                    if line not in existing.header_verbatim_lines:
+                        existing.header_verbatim_lines.append(line)
                 for inc in cls.user_includes:
                     if inc not in existing.user_includes:
                         existing.user_includes.append(inc)
@@ -96,6 +99,9 @@ def merge_modules(modules: list[OZModule]) -> OZModule:
         for line in m.verbatim_lines:
             if line not in merged.verbatim_lines:
                 merged.verbatim_lines.append(line)
+        for line in m.header_verbatim_lines:
+            if line not in merged.header_verbatim_lines:
+                merged.header_verbatim_lines.append(line)
         for inc in m.user_includes:
             if inc not in merged.user_includes:
                 merged.user_includes.append(inc)
@@ -294,6 +300,9 @@ def _walk(node: dict, module: OZModule, impl_name: str | None = None,
         _collect_interface(node, module)
     elif kind == "ObjCImplementationDecl":
         _collect_implementation(node, module)
+        name = node.get("name", "")
+        if name and _is_from_main_file(node):
+            module._main_impl_classes.add(name)
         return  # children handled inside
     elif kind == "ObjCProtocolDecl":
         _collect_protocol(node, module)
@@ -787,6 +796,93 @@ def _scan_includes(path: Path, module: OZModule) -> None:
                     module.user_includes.append(line)
 
 
+_OBJC_TS_NODE_TYPES = frozenset({
+    "class_interface",
+    "class_implementation",
+    "protocol_declaration",
+    "category_interface",
+    "category_implementation",
+    "class_forward_declaration",
+    "protocol_forward_declaration",
+})
+
+
+def _scan_header_verbatim(path: Path, module: OZModule) -> None:
+    """Scan a companion header for non-ObjC content to preserve verbatim.
+
+    Collects struct/union/enum definitions, macro calls, #define directives,
+    and any other non-ObjC top-level content from the header file.  These are
+    stored in module.header_verbatim_lines and later emitted in the generated
+    _ozh.h so that user-defined types and macros are not silently dropped.
+    """
+    if not path.is_file():
+        return
+    source = path.read_bytes()
+    parser = Parser(_TS_LANG)
+    tree = parser.parse(source)
+
+    children = tree.root_node.children
+
+    # Detect include-guard pattern: if the entire file is wrapped in a single
+    # preproc_ifdef / preproc_ifndef, descend into its children instead.
+    if (len(children) == 1
+            and children[0].type in ("preproc_ifdef", "preproc_ifndef")):
+        children = children[0].children
+
+    # Tree-sitter splits "struct foo { ... };" into struct_specifier + ";"
+    # as separate sibling nodes.  Merge trailing semicolons into the previous
+    # collected verbatim line so definitions are syntactically complete.
+    _NEEDS_SEMI = frozenset({
+        "struct_specifier", "union_specifier", "enum_specifier",
+    })
+
+    for i, child in enumerate(children):
+        if child.type in _OBJC_TS_NODE_TYPES:
+            continue
+        if child.type in ("preproc_include", "preproc_import"):
+            continue
+        if child.type in ("comment", "identifier", "#endif"):
+            continue
+
+        # Absorb standalone ";" — already merged with previous node below
+        if child.type == ";":
+            continue
+
+        text = source[child.start_byte:child.end_byte].decode()
+        stripped = text.strip()
+
+        # Skip #import/#include that tree-sitter may classify differently
+        if stripped.startswith(("#import", "#include")):
+            continue
+        # Skip #pragma once (generated header already has it)
+        if stripped == "#pragma once":
+            continue
+        # Skip bare include-guard #define with no value (e.g. #define HEADER_H_)
+        # but keep #define macros that have a value or body
+        if child.type == "preproc_def":
+            has_value = any(c.type == "preproc_arg"
+                           for c in child.children)
+            if not has_value:
+                continue
+        # Skip empty / whitespace-only fragments
+        if not stripped:
+            continue
+        # Skip preproc_ifdef / preproc_ifndef tokens (#ifndef, #endif, etc.)
+        if child.type in ("preproc_ifdef", "preproc_ifndef",
+                          "#ifndef", "#ifdef", "#endif"):
+            continue
+
+        # Merge trailing semicolon for type specifiers
+        if child.type in _NEEDS_SEMI:
+            end = child.end_byte
+            if i + 1 < len(children) and children[i + 1].type == ";":
+                end = children[i + 1].end_byte
+            text = source[child.start_byte:end].decode()
+
+        if text not in module.header_verbatim_lines:
+            module.header_verbatim_lines.append(text)
+
+
 def _collect_verbatim_lines(ast_root: dict, module: OZModule) -> None:
     """Scan original source for top-level expression statements and includes."""
     main_file = _find_main_file(ast_root)
@@ -796,7 +892,7 @@ def _collect_verbatim_lines(ast_root: dict, module: OZModule) -> None:
     if not path.is_file():
         return
 
-    # Also scan companion header file(s) for user includes
+    # Also scan companion header file(s) for user includes and verbatim content
     header_candidates = [
         path.with_suffix(".h"),
         path.parent / "include" / (path.stem + ".h"),
@@ -804,6 +900,7 @@ def _collect_verbatim_lines(ast_root: dict, module: OZModule) -> None:
     ]
     for header in header_candidates:
         _scan_includes(header, module)
+        _scan_header_verbatim(header, module)
 
     source = path.read_bytes()
     parser = Parser(_TS_LANG)
@@ -856,6 +953,15 @@ def _distribute_verbatim_to_classes(module: OZModule) -> None:
     if len(impl_classes) == 1 and module.verbatim_lines:
         impl_classes[0].verbatim_lines = module.verbatim_lines
         module.verbatim_lines = []
+    # Header verbatim lines go to the main-file implementation class
+    if impl_classes and module.header_verbatim_lines:
+        main_classes = getattr(module, "_main_impl_classes", set())
+        main_impl = [c for c in impl_classes if c.name in main_classes]
+        target = main_impl[0] if main_impl else impl_classes[0]
+        for line in module.header_verbatim_lines:
+            if line not in target.header_verbatim_lines:
+                target.header_verbatim_lines.append(line)
+        module.header_verbatim_lines = []
 
 
 def _has_struct_definition(node) -> bool:

--- a/tools/oz_transpile/emit.py
+++ b/tools/oz_transpile/emit.py
@@ -524,6 +524,14 @@ def _class_header_ctx(ctx: _EmitCtx, stem: str | None = None,
         for p in func.params:
             _add_type_def(p.oz_type.raw_qual_type)
 
+    # OZ-090: deduplicate type_defs already present in header verbatim lines
+    if cls.header_verbatim_lines:
+        hdr_text = "\n".join(cls.header_verbatim_lines)
+        type_defs = [td for td in type_defs
+                     if not any(key in hdr_text
+                                for key in module.type_defs
+                                if module.type_defs[key] == td)]
+
     function_protos = []
     for func in cls.functions:
         if func.is_static:
@@ -597,6 +605,7 @@ def _class_header_ctx(ctx: _EmitCtx, stem: str | None = None,
         "q31_inits": q31_inits,
         "item_pool_count": item_pool_count,
         "user_includes": cls.user_includes,
+        "header_verbatim_lines": cls.header_verbatim_lines,
         "has_atomic_props": has_atomic_props,
         "heap_support": heap_support,
         "inline_accessors": inline_accessors,

--- a/tools/oz_transpile/model.py
+++ b/tools/oz_transpile/model.py
@@ -279,6 +279,7 @@ class OZClass:
     class_id: int = -1
     base_depth: int = 0
     verbatim_lines: list[str] = field(default_factory=list)
+    header_verbatim_lines: list[str] = field(default_factory=list)
     user_includes: list[str] = field(default_factory=list)
     functions: list[OZFunction] = field(default_factory=list)
     statics: list[OZStaticVar] = field(default_factory=list)
@@ -320,6 +321,7 @@ class OZModule:
     functions: list[OZFunction] = field(default_factory=list)
     statics: list[OZStaticVar] = field(default_factory=list)
     verbatim_lines: list[str] = field(default_factory=list)
+    header_verbatim_lines: list[str] = field(default_factory=list)
     user_includes: list[str] = field(default_factory=list)
     type_defs: dict[str, str] = field(default_factory=dict)
     diagnostics: list[str] = field(default_factory=list)
@@ -330,3 +332,4 @@ class OZModule:
     source_path: Path | None = None
     source_paths: dict[str, Path] = field(default_factory=dict)
     orphan_sources: list[OrphanSource] = field(default_factory=list)
+    _main_impl_classes: set[str] = field(default_factory=set)

--- a/tools/oz_transpile/templates/class_header.h.j2
+++ b/tools/oz_transpile/templates/class_header.h.j2
@@ -10,6 +10,10 @@
 {% for inc in user_includes %}
 {{ inc }}
 {% endfor %}
+{% for line in header_verbatim_lines %}
+
+{{ line }}
+{% endfor %}
 {% for td in ivar_type_defs %}
 
 {{ td }}

--- a/tools/oz_transpile/tests/test_emit.py
+++ b/tools/oz_transpile/tests/test_emit.py
@@ -4728,3 +4728,175 @@ int public_helper(int x)
 """, stem="Foo")
         header = out["Foo_ozh.h"]
         assert "int public_helper(int x);" in header
+
+
+# ===========================================================================
+# OZ-090: Header content preservation — structs, unions, enums, macros, etc.
+# ===========================================================================
+
+_OZ090_HEADER = """\
+#pragma once
+#import <Foundation/OZObject.h>
+
+enum test_state {
+    TEST_IDLE = 0,
+    TEST_RUNNING,
+    TEST_DONE,
+};
+
+struct test_msg {
+    enum test_state state;
+    int value;
+};
+
+union test_data {
+    int i;
+    float f;
+};
+
+#define TEST_MAX_ITEMS 64
+
+static inline int test_clamp(int v, int lo, int hi)
+{
+    if (v < lo) {
+        return lo;
+    }
+    if (v > hi) {
+        return hi;
+    }
+    return v;
+}
+
+#define DECLARE_CHANNEL(name) extern int name##_channel
+DECLARE_CHANNEL(test);
+
+@interface Sensor : OZObject
+- (void)run;
+@end
+"""
+
+_OZ090_SOURCE = """\
+#import "source.h"
+
+@implementation Sensor
+- (void)run {
+}
+@end
+"""
+
+
+class TestHeaderVerbatimPreservation:
+    """OZ-090: non-ObjC content in companion headers must be preserved."""
+
+    def test_struct_not_used_by_objc_preserved(self):
+        """struct defined in header but not used by @interface must appear."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "struct test_msg" in header
+        assert "enum test_state state;" in header
+
+    def test_union_not_used_by_objc_preserved(self):
+        """union defined in header but not used by @interface must appear."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "union test_data" in header
+        assert "int i;" in header
+        assert "float f;" in header
+
+    def test_enum_not_used_by_objc_preserved(self):
+        """enum defined in header but not used by @interface must appear."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "TEST_IDLE" in header
+        assert "TEST_RUNNING" in header
+        assert "TEST_DONE" in header
+
+    def test_define_macro_preserved(self):
+        """#define with value in header must be preserved."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "#define TEST_MAX_ITEMS 64" in header
+
+    def test_static_inline_function_preserved(self):
+        """static inline function in header must be preserved."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "static inline int test_clamp" in header
+
+    def test_macro_call_preserved(self):
+        """Macro call (expression_statement) in header must be preserved."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "DECLARE_CHANNEL(test)" in header
+
+    def test_function_like_define_preserved(self):
+        """Function-like #define macro in header must be preserved."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        assert "#define DECLARE_CHANNEL(name)" in header
+
+    def test_no_type_def_duplication(self):
+        """Types in header verbatim must not also appear as ivar_type_defs."""
+        _, out = clang_emit(
+            _OZ090_SOURCE,
+            extra_files={"source.h": _OZ090_HEADER})
+        header = out["Sensor_ozh.h"]
+        # enum test_state should appear exactly once (from verbatim, not type_defs)
+        count = header.count("enum test_state {")
+        assert count == 1, f"enum test_state {{ appeared {count} times"
+
+    def test_referenced_type_still_works_with_verbatim(self):
+        """Types used in @interface still work when also in header verbatim."""
+        hdr = """\
+#import <Foundation/OZObject.h>
+enum color { RED = 0, GREEN, BLUE };
+@interface Pal : OZObject {
+    enum color _c;
+}
+@end
+"""
+        _, out = clang_emit("""\
+#import "source.h"
+@implementation Pal
+@end
+""", extra_files={"source.h": hdr})
+        header = out["Pal_ozh.h"]
+        assert "RED" in header
+        # Should appear once from verbatim, deduped from ivar_type_defs
+        count = header.count("enum color {")
+        assert count == 1, f"enum color {{ appeared {count} times"
+
+    def test_include_guard_header_content_preserved(self):
+        """Header with #ifndef include guards must still have content preserved."""
+        hdr = """\
+#ifndef SOURCE_H_
+#define SOURCE_H_
+#import <Foundation/OZObject.h>
+struct guarded_type { int x; };
+@interface Grd : OZObject
+- (void)run;
+@end
+#endif
+"""
+        _, out = clang_emit("""\
+#import "source.h"
+@implementation Grd
+- (void)run {}
+@end
+""", extra_files={"source.h": hdr})
+        header = out["Grd_ozh.h"]
+        assert "struct guarded_type" in header


### PR DESCRIPTION
## Summary
- Closes #182 (OZ-090: Transpiler drops struct definitions from headers that are not used in ObjC interfaces)
- Scans companion `.h` files with tree-sitter and emits all non-ObjC content (structs, unions, enums, macros, `#define`, static inline functions) in the generated `_ozh.h` header

## Changes
- `collect.py`: new `_scan_header_verbatim()` function parses companion headers; tracks main-file implementations to distribute verbatim lines to the correct class
- `emit.py`: passes `header_verbatim_lines` to template context; deduplicates type_defs already covered by verbatim lines
- `model.py`: adds `header_verbatim_lines` field to `OZModule` and `OZClass`
- `class_header.h.j2`: new template section for header verbatim content
- New regression test runner (`test_regression.py`) + comprehensive test case

## Embedded Considerations
- Footprint: no change (verbatim content was always in the user's header)
- Performance: no change (tree-sitter scan happens at transpile time, not runtime)
- Reliability: prevents silent code loss from companion headers

## Test Plan
- [x] `just test-transpiler` — 527 passed (10 new OZ-090 tests)
- [x] `just test-behavior` — 73 passed (1 new regression with 8 sub-tests)
- [x] `just test-adapted` — 40 passed
- [x] `just test` — 11/11 twister configurations passed